### PR TITLE
Handle entradas with modal confirmation

### DIFF
--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -5,7 +5,7 @@ import {
   collection, addDoc, updateDoc, doc, getDoc, Timestamp
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
-import { mostrarErro } from './utils.js';
+import { mostrarErro, normalizarTexto } from './utils.js';
 
 let produtoCadastroAtual = null;
 
@@ -79,6 +79,8 @@ window.confirmarEntradaEstoque = async function () {
     const produto = produtoSnap.data();
     const quantidade = produtoCadastroAtual.quantidade || 0;
     const precoUnitario = produtoCadastroAtual.precoCompra || 0;
+    const validadeEntrada = produtoCadastroAtual.validade ? new Date(produtoCadastroAtual.validade) : null;
+    const lote = produtoCadastroAtual.lote || "";
     const custoTotal = quantidade * precoUnitario;
     const dataTimestamp = Timestamp.fromDate(dataMov);
 
@@ -104,6 +106,7 @@ window.confirmarEntradaEstoque = async function () {
     await addDoc(collection(db, "movimentacoes"), {
       produtoId: produtoCadastroAtual.id,
       nomeProduto: produto.nome,
+      nomeBusca: normalizarTexto(produto.nome),
       categoria: produto.categoria,
       fornecedor: produto.fornecedor,
       unidadeMedida: produto.unidadeMedida || "-",
@@ -113,6 +116,8 @@ window.confirmarEntradaEstoque = async function () {
       custoTotal,
       dataMovimentacao: dataTimestamp,
       observacao: observacoes,
+      validade: validadeEntrada ? Timestamp.fromDate(validadeEntrada) : null,
+      lote,
       parcelas: parcelas,
       usuario: "admin@zelia.com"
     });

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -19,6 +19,7 @@ import {
   cancelarConfirmacao,
   confirmarAcao
 } from './modais.js';
+import { abrirModalEntrada } from './modalEntrada.js';
 
 // =========================
 // 🔥 Variáveis Globais
@@ -389,8 +390,24 @@ document.getElementById("form-movimentacao").addEventListener("submit", async (e
     return;
   }
 
+  if (tipo === "entrada") {
+    abrirModalEntrada({
+      id: produtoEncontrado.id,
+      nome: produto.nome,
+      categoria: produto.categoria,
+      fornecedor: produto.fornecedor,
+      unidadeMedida: produto.unidadeMedida || "unidade",
+      quantidade,
+      precoCompra: precoUnitario,
+      dataEntrada: dataMov,
+      validade,
+      lote
+    });
+    return;
+  }
+
   abrirModalConfirmacao(
-    `Deseja confirmar ${tipo === "entrada" ? "entrada" : "saída"} de ${quantidade} unidade(s) do produto "${produto.nome}"?`,
+    `Deseja confirmar saída de ${quantidade} unidade(s) do produto "${produto.nome}"?`,
     async () => {
       try {
         await updateDoc(produtoRef, { quantidade: novaQuantidade });
@@ -404,7 +421,7 @@ document.getElementById("form-movimentacao").addEventListener("submit", async (e
           categoria: produto.categoria,
           fornecedor: produto.fornecedor,
           unidadeMedida: produto.unidadeMedida || "unidade",
-          tipo,
+          tipo: "saida",
           quantidade,
           precoUnitario,
           custoTotal: quantidade * precoUnitario,

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -113,9 +113,55 @@
     <div class="spinner"></div>
   </div>
 
+  <!-- 🔧 Fundo do Modal de Entrada -->
+  <div id="fundo-modal" class="fundo-modal"></div>
+
+  <!-- ✅ Modal de Entrada de Produto -->
+  <div id="modal-entrada" class="modal">
+    <div class="modal-content">
+      <h3 id="nome-produto-modal">Produto:</h3>
+
+      <label>Identificador da Compra (compraId):</label>
+      <div style="display: flex; gap: 10px;">
+        <input type="text" id="entrada-compra-id" placeholder="Ex: compra_20250604_001" style="flex: 1;" />
+        <button type="button" onclick="gerarNovoCompraId()">+ Nova Compra</button>
+      </div>
+
+      <label>Forma de Pagamento:</label>
+      <select id="entrada-forma-pagamento">
+        <option value="pix">PIX</option>
+        <option value="boleto">Boleto</option>
+        <option value="cartao">Cartão</option>
+        <option value="dinheiro">Dinheiro</option>
+        <option value="transferencia">Transferência</option>
+      </select>
+
+      <label>Número do boleto / transação:</label>
+      <input type="text" id="entrada-identificador-pagamento" placeholder="Opcional" />
+
+      <label>Número de Parcelas:</label>
+      <input type="number" id="entrada-numero-parcelas" min="1" value="1" />
+
+      <label>Data do Primeiro Vencimento:</label>
+      <input type="date" id="entrada-primeiro-vencimento" />
+
+      <!-- Gerador de parcelas -->
+      <div id="parcelas-container" style="margin-top:10px;"></div>
+
+      <label>Observações:</label>
+      <textarea id="entrada-observacoes" rows="2"></textarea>
+
+      <div style="margin-top: 15px; text-align: right;">
+        <button onclick="fecharModalEntrada()">Cancelar</button>
+        <button onclick="confirmarEntradaEstoque()">Confirmar Entrada</button>
+      </div>
+    </div>
+  </div>
+
   <!-- 🔥 Scripts -->
   <script type="module" src="js/auth.js"></script>
   <script type="module" src="js/utils.js"></script>
+  <script type="module" src="js/modalEntrada.js"></script>
   <script type="module" src="js/modais.js"></script>
   <script type="module" src="js/movimentacoes.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- load modalEntrada.js in movimentações page and include modal markup
- open modalEntrada when submitting an entrada movimentação
- update confirmarEntradaEstoque to persist entrada data with validade and lote

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849aeded728832bb4778aebb09c2787