### PR TITLE
Fix cancel action in entry modal

### DIFF
--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -267,3 +267,6 @@ function atualizarParcelasPreview() {
 document.getElementById("entrada-numero-parcelas").addEventListener("input", atualizarParcelasPreview);
 document.getElementById("entrada-primeiro-vencimento").addEventListener("change", atualizarParcelasPreview);
 
+// Tornar funções acessíveis globalmente para os botões do modal
+window.fecharModalEntrada = fecharModalEntrada;
+


### PR DESCRIPTION
## Summary
- make `fecharModalEntrada` accessible to inline button handlers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c408f33c8832bb3513e5f9af25dc7