### PR TITLE
Improve financial report with parcel details

### DIFF
--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -13,8 +13,7 @@ export async function atualizarTabelaFinanceiro() {
   try {
     mostrarSpinner();
 
-    const periodoMeses = parseInt(document.getElementById("input-meses-fin")?.value) || 3;
-    dadosFinanceiro = await carregarDadosFinanceiro(periodoMeses);
+    dadosFinanceiro = await carregarDadosFinanceiro();
 
     setDadosFinanceiro(dadosFinanceiro);
     gerarFiltrosFinanceiro();
@@ -30,11 +29,12 @@ export async function atualizarTabelaFinanceiro() {
 
 // 🧹 Limpar filtros
 export function limparFiltrosFinanceiro() {
-  document.getElementById("input-meses-fin").value = 3;
-  document.getElementById("filtro-descricao").value = "";
-  document.getElementById("filtro-categoria-fin").value = "";
-  document.getElementById("filtro-status-fin").value = "";
-  document.getElementById("filtro-mes-fin").value = "";
+  document.getElementById('fin-data-inicio').value = '';
+  document.getElementById('fin-data-fim').value = '';
+  document.getElementById('fin-compra-id').value = '';
+  document.getElementById('fin-fornecedor').value = '';
+  document.getElementById('fin-forma').value = '';
+  document.getElementById('fin-status').value = '';
 
   gerarTabelaFinanceiro();
 }
@@ -54,3 +54,32 @@ document.addEventListener("DOMContentLoaded", () => {
 
   atualizarTabelaFinanceiro();
 });
+
+// 📑 Modal de parcelas
+window.abrirModalParcelas = function (compraId) {
+  const registro = dadosFinanceiro.find(d => d.compraId === compraId);
+  if (!registro) return;
+
+  document.getElementById('modal-compra-id').textContent = compraId;
+  const cont = document.getElementById('parcelas-detalhes');
+
+  if (!registro.parcelas || registro.parcelas.length === 0) {
+    cont.innerHTML = '<p>Sem parcelas cadastradas.</p>';
+  } else {
+    let html = `<table class="tabela"><thead><tr><th>#</th><th>Valor</th><th>Vencimento</th><th>Status</th></tr></thead><tbody>`;
+    registro.parcelas.forEach(p => {
+      const venc = p.vencimento ? new Date(p.vencimento).toLocaleDateString('pt-BR') : '-';
+      html += `<tr><td>${p.numero}</td><td>R$ ${(p.valor || 0).toFixed(2)}</td><td>${venc}</td><td>${p.status}</td></tr>`;
+    });
+    html += '</tbody></table>';
+    cont.innerHTML = html;
+  }
+
+  document.getElementById('modal-parcelas').style.display = 'block';
+  document.getElementById('fundo-modal-parcelas').style.display = 'block';
+};
+
+window.fecharModalParcelas = function () {
+  document.getElementById('modal-parcelas').style.display = 'none';
+  document.getElementById('fundo-modal-parcelas').style.display = 'none';
+};

--- a/js/relatorios/financeiroDados.js
+++ b/js/relatorios/financeiroDados.js
@@ -19,6 +19,20 @@ export async function carregarDadosFinanceiro(periodoMeses = 3) {
       const dataVenc = d.dataVencimento?.toDate?.() || null;
       const dataPag = d.dataPagamento?.toDate?.() || null;
 
+      const parcelas = Array.isArray(d.parcelas) ? d.parcelas : [];
+
+      const hoje = new Date();
+      let statusParcelas = "paga";
+      let temVencida = false;
+      parcelas.forEach(p => {
+        const venc = p.vencimento ? new Date(p.vencimento) : null;
+        if (p.status !== "pago") {
+          statusParcelas = "pendente";
+          if (venc && venc < hoje) temVencida = true;
+        }
+      });
+      if (temVencida) statusParcelas = "vencida";
+
       return {
         id: doc.id,
         tipo: d.tipo || "-",
@@ -26,6 +40,9 @@ export async function carregarDadosFinanceiro(periodoMeses = 3) {
         categoria: d.categoria || "-",
         valor: Number(d.valorTotal) || 0,
         status: d.status || "pendente",
+        compraId: d.compraId || "-",
+        parcelas,
+        statusParcelas,
         fornecedorOuCliente: d.fornecedorOuCliente || "-",
         formaPagamento: d.formaPagamento || "-",
         dataLancamento: dataLanc,

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -3,7 +3,6 @@
 import { normalizarTexto } from '../utils.js';
 
 let dados = [];
-let ordemCrescente = true;
 
 // 🔥 Setar dados
 export function setDadosFinanceiro(novosDados) {
@@ -12,42 +11,56 @@ export function setDadosFinanceiro(novosDados) {
 
 // 🔍 Gerar filtros dinâmicos
 export function gerarFiltrosFinanceiro() {
-  const categorias = new Set();
-  const status = new Set();
-  const meses = new Set();
+  const fornecedores = new Set();
+  const formas = new Set();
+  const compras = new Set();
+  const statusParcelas = new Set();
 
   dados.forEach(d => {
-    if (d.categoria) categorias.add(d.categoria);
-    if (d.status) status.add(d.status);
-    if (d.mes) meses.add(d.mes);
+    if (d.fornecedorOuCliente) fornecedores.add(d.fornecedorOuCliente);
+    if (d.formaPagamento) formas.add(d.formaPagamento);
+    if (d.compraId) compras.add(d.compraId);
+    if (d.statusParcelas) statusParcelas.add(d.statusParcelas);
   });
 
-  document.getElementById("filtro-categoria-fin").innerHTML =
-    `<option value="">Todas</option>` + [...categorias].sort().map(c => `<option value="${c}">${c}</option>`).join("");
+  document.getElementById('fin-fornecedor').innerHTML =
+    `<option value="">Fornecedor</option>` +
+    [...fornecedores].sort().map(f => `<option value="${f}">${f}</option>`).join('');
 
-  document.getElementById("filtro-status-fin").innerHTML =
-    `<option value="">Todos</option>` + [...status].sort().map(s => `<option value="${s}">${s}</option>`).join("");
+  document.getElementById('fin-forma').innerHTML =
+    `<option value="">Forma</option>` +
+    [...formas].sort().map(f => `<option value="${f}">${f}</option>`).join('');
 
-  document.getElementById("filtro-mes-fin").innerHTML =
-    `<option value="">Todos</option>` + [...meses].sort().map(m => `<option value="${m}">${m}</option>`).join("");
+  document.getElementById('fin-status').innerHTML =
+    `<option value="">Status</option>` +
+    [...statusParcelas].sort().map(s => `<option value="${s}">${s}</option>`).join('');
+
+  document.getElementById('lista-compra-fin').innerHTML =
+    [...compras].sort().map(c => `<option value="${c}">`).join('');
 }
 
 // 📊 Renderizar Tabela
 export function gerarTabelaFinanceiro() {
   const lista = document.getElementById("tabela-financeiro");
 
-  const descricaoFiltro = normalizarTexto(document.getElementById("filtro-descricao").value.trim());
-  const categoriaFiltro = document.getElementById("filtro-categoria-fin").value;
-  const statusFiltro = document.getElementById("filtro-status-fin").value;
-  const mesFiltro = document.getElementById("filtro-mes-fin").value;
+  const fornecedorFiltro = document.getElementById('fin-fornecedor').value;
+  const formaFiltro = document.getElementById('fin-forma').value;
+  const compraFiltro = document.getElementById('fin-compra-id').value.trim();
+  const statusFiltro = document.getElementById('fin-status').value;
+  const inicio = document.getElementById('fin-data-inicio').value;
+  const fim = document.getElementById('fin-data-fim').value;
 
   const filtrados = dados.filter(d => {
-    const nomeMatch = normalizarTexto(d.descricao).includes(descricaoFiltro);
-    const categoriaMatch = categoriaFiltro === "" || d.categoria === categoriaFiltro;
-    const statusMatch = statusFiltro === "" || d.status === statusFiltro;
-    const mesMatch = mesFiltro === "" || d.mes === mesFiltro;
+    const fornMatch = fornecedorFiltro === '' || d.fornecedorOuCliente === fornecedorFiltro;
+    const formaMatch = formaFiltro === '' || d.formaPagamento === formaFiltro;
+    const compraMatch = compraFiltro === '' || d.compraId === compraFiltro;
+    const statusMatch = statusFiltro === '' || d.statusParcelas === statusFiltro;
 
-    return nomeMatch && categoriaMatch && statusMatch && mesMatch;
+    let dataMatch = true;
+    if (inicio) dataMatch = d.dataLancamento && d.dataLancamento >= new Date(inicio);
+    if (fim) dataMatch = dataMatch && d.dataLancamento && d.dataLancamento <= new Date(fim);
+
+    return fornMatch && formaMatch && compraMatch && statusMatch && dataMatch;
   });
 
   if (filtrados.length === 0) {
@@ -59,32 +72,30 @@ export function gerarTabelaFinanceiro() {
     <table class="tabela">
       <thead>
         <tr>
-          <th onclick="ordenarPorDescricao()" style="cursor:pointer;">Descrição ⬍</th>
-          <th>Categoria</th>
-          <th>Valor</th>
-          <th>Status</th>
-          <th>Data Lançamento</th>
-          <th>Vencimento</th>
-          <th>Pagamento</th>
+          <th>CompraID</th>
+          <th>Fornecedor</th>
+          <th>Data da compra</th>
+          <th>Forma de pagamento</th>
+          <th>Valor total</th>
+          <th>Parcelas</th>
         </tr>
       </thead>
       <tbody>
   `;
 
   filtrados.forEach(d => {
-    const lanc = d.dataLancamento?.toLocaleDateString('pt-BR') || "-";
-    const venc = d.dataVencimento?.toLocaleDateString('pt-BR') || "-";
-    const pag = d.dataPagamento?.toLocaleDateString('pt-BR') || "-";
-
+    const lanc = d.dataLancamento?.toLocaleDateString('pt-BR') || '-';
     html += `
       <tr>
-        <td>${d.descricao}</td>
-        <td>${d.categoria}</td>
-        <td>R$ ${(d.valor).toFixed(2)}</td>
-        <td>${d.status}</td>
+        <td>${d.compraId}</td>
+        <td>${d.fornecedorOuCliente}</td>
         <td>${lanc}</td>
-        <td>${venc}</td>
-        <td>${pag}</td>
+        <td>${d.formaPagamento}</td>
+        <td>R$ ${(d.valor).toFixed(2)}</td>
+        <td>
+          ${d.parcelas.length} (${d.statusParcelas})
+          <button onclick="abrirModalParcelas('${d.compraId}')">Ver</button>
+        </td>
       </tr>
     `;
   });
@@ -92,17 +103,3 @@ export function gerarTabelaFinanceiro() {
   html += `</tbody></table>`;
   lista.innerHTML = html;
 }
-
-// 🔃 Ordenar por descrição
-window.ordenarPorDescricao = function () {
-  dados.sort((a, b) => {
-    const nomeA = (a.descricao || "").toLowerCase();
-    const nomeB = (b.descricao || "").toLowerCase();
-    if (nomeA < nomeB) return ordemCrescente ? -1 : 1;
-    if (nomeA > nomeB) return ordemCrescente ? 1 : -1;
-    return 0;
-  });
-
-  ordemCrescente = !ordemCrescente;
-  gerarTabelaFinanceiro();
-};

--- a/relatorios.html
+++ b/relatorios.html
@@ -118,12 +118,16 @@
       <h2>💰 Financeiro</h2>
 
       <div class="filtros">
-        <label>Período (meses):</label>
-        <input type="number" id="input-meses-fin" value="3" min="1" style="width: 60px;">
-        <input type="text" id="filtro-descricao" placeholder="🔍 Descrição...">
-        <select id="filtro-categoria-fin"></select>
-        <select id="filtro-status-fin"></select>
-        <select id="filtro-mes-fin"></select>
+        <label>De:</label>
+        <input type="date" id="fin-data-inicio">
+        <label>Até:</label>
+        <input type="date" id="fin-data-fim">
+
+        <input type="text" id="fin-compra-id" placeholder="CompraID" list="lista-compra-fin" style="width:140px;">
+        <datalist id="lista-compra-fin"></datalist>
+        <select id="fin-fornecedor"></select>
+        <select id="fin-forma"></select>
+        <select id="fin-status"></select>
 
         <button id="botao-atualizar-fin">🔄 Atualizar</button>
         <button id="botao-limpar-fin">🧹 Limpar</button>
@@ -139,6 +143,17 @@
       </div>
 
       <div id="tabela-financeiro"></div>
+
+      <div id="modal-parcelas" class="modal">
+        <div class="modal-content">
+          <h3>Parcelas - Compra <span id="modal-compra-id"></span></h3>
+          <div id="parcelas-detalhes"></div>
+          <div style="margin-top:10px; text-align:right;">
+            <button onclick="fecharModalParcelas()">Fechar</button>
+          </div>
+        </div>
+      </div>
+      <div id="fundo-modal-parcelas" class="fundo-modal"></div>
     </div>
 
 


### PR DESCRIPTION
## Summary
- add date range and supplier filters for financial report
- compute parcel status when loading financial records
- render new finance table with parcel count and detail modal
- implement modal to view all installments for a purchase

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d839b0688832ba00a7f06cc6efd44