### PR TITLE
Move financeiro page and fix filters

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -17,6 +17,7 @@
         <ul>
           <li><a href="produtos.html">📦 Produtos</a></li>
           <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
+          <li><a href="financeiro.html">💰 Financeiro</a></li>
           <li><a href="relatorios.html">📊 Relatórios</a></li>
         </ul>
       </nav>

--- a/financeiro.html
+++ b/financeiro.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Zélia - Financeiro</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<div class="app-container">
+  <aside class="sidebar">
+    <div class="logo">
+      <img src="img/logo-zelia.png" alt="Logo Zélia" />
+    </div>
+    <nav>
+      <ul>
+        <li><a href="dashboard.html">🏠 Dashboard</a></li>
+        <li><a href="produtos.html">📦 Produtos</a></li>
+        <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
+        <li><a class="ativo" href="financeiro.html">💰 Financeiro</a></li>
+        <li><a href="relatorios.html">📊 Relatórios</a></li>
+      </ul>
+    </nav>
+    <button onclick="logout()">Sair</button>
+  </aside>
+
+  <main class="main-content">
+    <h1>💰 Financeiro</h1>
+
+    <div class="filtros">
+      <label>De:</label>
+      <input type="date" id="fin-data-inicio">
+      <label>Até:</label>
+      <input type="date" id="fin-data-fim">
+
+      <input type="text" id="fin-compra-id" placeholder="CompraID" list="lista-compra-fin" style="width:140px;">
+      <datalist id="lista-compra-fin"></datalist>
+      <select id="fin-fornecedor"></select>
+      <select id="fin-forma"></select>
+      <select id="fin-status"></select>
+
+      <button id="botao-atualizar-fin">🔄 Atualizar</button>
+      <button id="botao-limpar-fin">🧹 Limpar</button>
+      <button id="botao-exportar-csv-fin">📄 CSV</button>
+      <button id="botao-exportar-excel-fin">📊 Excel</button>
+    </div>
+
+    <div id="cards-financeiro" class="cards">
+      <div class="card"><strong>A pagar:</strong> <span id="total-pagar">-</span></div>
+      <div class="card"><strong>Pagos:</strong> <span id="total-pagos">-</span></div>
+      <div class="card"><strong>Recebidos:</strong> <span id="total-recebidos">-</span></div>
+    </div>
+
+    <div id="tabela-financeiro"></div>
+
+    <div id="modal-parcelas" class="modal">
+      <div class="modal-content">
+        <h3>Parcelas - Compra <span id="modal-compra-id"></span></h3>
+        <div id="parcelas-detalhes"></div>
+        <div style="margin-top:10px; text-align:right;">
+          <button onclick="fecharModalParcelas()">Fechar</button>
+        </div>
+      </div>
+    </div>
+    <div id="fundo-modal-parcelas" class="fundo-modal"></div>
+  </main>
+</div>
+
+<div id="spinner" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.2); align-items:center; justify-content:center; z-index:2000;">
+  <div style="border:6px solid #ccc; border-top:6px solid #009688; border-radius:50%; width:40px; height:40px; animation:girar 1s linear infinite;"></div>
+</div>
+<style>
+@keyframes girar {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+</style>
+
+<script type="module" src="js/firebaseConfig.js"></script>
+<script type="module" src="js/utils.js"></script>
+<script type="module" src="js/modais.js"></script>
+<script type="module" src="js/relatorios/financeiro.js"></script>
+<script type="module" src="js/relatorios/financeiroExportar.js"></script>
+<script type="module" src="js/relatorios/financeiroGraficos.js"></script>
+<script type="module" src="js/relatorios/financeiroTotais.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+</body>
+</html>

--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -2,9 +2,10 @@
 
 import { carregarDadosFinanceiro } from './financeiroDados.js';
 import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro } from './financeiroTabela.js';
-import { atualizarCardsFinanceiro } from './financeiroTotais.js';
 import { exportarFinanceiroCSV, exportarFinanceiroExcel } from './financeiroExportar.js';
 import { mostrarSpinner, esconderSpinner } from '../utils.js';
+import { db } from '../firebaseConfig.js';
+import { collection, getDocs, query, where } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
 let dadosFinanceiro = [];
 
@@ -18,7 +19,6 @@ export async function atualizarTabelaFinanceiro() {
     setDadosFinanceiro(dadosFinanceiro);
     gerarFiltrosFinanceiro();
     gerarTabelaFinanceiro();
-    atualizarCardsFinanceiro(dadosFinanceiro);
 
   } catch (error) {
     console.error("❌ Erro ao atualizar financeiro:", error);
@@ -56,24 +56,44 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 // 📑 Modal de parcelas
-window.abrirModalParcelas = function (compraId) {
+window.abrirModalParcelas = async function (compraId) {
   const registro = dadosFinanceiro.find(d => d.compraId === compraId);
   if (!registro) return;
 
   document.getElementById('modal-compra-id').textContent = compraId;
   const cont = document.getElementById('parcelas-detalhes');
 
+  let html = '';
+
+  // Produtos relacionados
+  try {
+    const q = query(collection(db, 'movimentacoes'), where('compraId', '==', compraId), where('tipo', '==', 'entrada'));
+    const snap = await getDocs(q);
+    if (!snap.empty) {
+      html += '<h4>Produtos</h4><table class="tabela"><thead><tr><th>Produto</th><th>Qtd</th><th>Preço</th></tr></thead><tbody>';
+      snap.docs.forEach(doc => {
+        const d = doc.data();
+        html += `<tr><td>${d.nomeProduto}</td><td>${d.quantidade}</td><td>R$ ${(d.precoUnitario || 0).toFixed(2)}</td></tr>`;
+      });
+      html += '</tbody></table><br />';
+    }
+  } catch (e) {
+    console.error('Erro ao buscar produtos da compra', e);
+  }
+
+  // Parcelas
   if (!registro.parcelas || registro.parcelas.length === 0) {
-    cont.innerHTML = '<p>Sem parcelas cadastradas.</p>';
+    html += '<p>Sem parcelas cadastradas.</p>';
   } else {
-    let html = `<table class="tabela"><thead><tr><th>#</th><th>Valor</th><th>Vencimento</th><th>Status</th></tr></thead><tbody>`;
+    html += `<h4>Parcelas</h4><table class="tabela"><thead><tr><th>#</th><th>Valor</th><th>Vencimento</th><th>Status</th></tr></thead><tbody>`;
     registro.parcelas.forEach(p => {
       const venc = p.vencimento ? new Date(p.vencimento).toLocaleDateString('pt-BR') : '-';
       html += `<tr><td>${p.numero}</td><td>R$ ${(p.valor || 0).toFixed(2)}</td><td>${venc}</td><td>${p.status}</td></tr>`;
     });
     html += '</tbody></table>';
-    cont.innerHTML = html;
   }
+
+  cont.innerHTML = html;
 
   document.getElementById('modal-parcelas').style.display = 'block';
   document.getElementById('fundo-modal-parcelas').style.display = 'block';

--- a/js/relatorios/financeiroTotais.js
+++ b/js/relatorios/financeiroTotais.js
@@ -2,7 +2,6 @@
 
 export function calcularTotaisFinanceiro(dados) {
   let totalPagar = 0;
-  let totalReceber = 0;
   let pagos = 0;
   let recebidos = 0;
 
@@ -12,19 +11,17 @@ export function calcularTotaisFinanceiro(dados) {
       if (d.status === "pago") pagos += d.valor;
     }
     if (d.tipo === "receber") {
-      totalReceber += d.valor;
       if (d.status === "recebido") recebidos += d.valor;
     }
   });
 
-  return { totalPagar, totalReceber, pagos, recebidos };
+  return { totalPagar, pagos, recebidos };
 }
 
 export function atualizarCardsFinanceiro(dados) {
   const totais = calcularTotaisFinanceiro(dados);
 
   document.getElementById("total-pagar").textContent = `R$ ${totais.totalPagar.toFixed(2)}`;
-  document.getElementById("total-receber").textContent = `R$ ${totais.totalReceber.toFixed(2)}`;
   document.getElementById("total-pagos").textContent = `R$ ${totais.pagos.toFixed(2)}`;
   document.getElementById("total-recebidos").textContent = `R$ ${totais.recebidos.toFixed(2)}`;
 }

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -16,6 +16,7 @@
         <ul>
           <li><a href="dashboard.html">🏠 Dashboard</a></li>
           <li><a href="produtos.html">📦 Produtos</a></li>
+          <li><a href="financeiro.html">💰 Financeiro</a></li>
           <li><a href="relatorios.html">📊 Relatórios</a></li>
         </ul>
       </nav>

--- a/produtos.html
+++ b/produtos.html
@@ -17,6 +17,7 @@
         <ul>
           <li><a href="dashboard.html">🏠 Dashboard</a></li>
           <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
+          <li><a href="financeiro.html">💰 Financeiro</a></li>
           <li><a href="relatorios.html">📊 Relatórios</a></li>
         </ul>
       </nav>

--- a/relatorios.html
+++ b/relatorios.html
@@ -19,6 +19,7 @@
         <li><a href="dashboard.html">🏠 Dashboard</a></li>
         <li><a href="produtos.html">📦 Produtos</a></li>
         <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
+        <li><a href="financeiro.html">💰 Financeiro</a></li>
         <li><a class="ativo" href="relatorios.html">📊 Relatórios</a></li>
       </ul>
     </nav>
@@ -34,7 +35,6 @@
       <button class="aba ativa" onclick="abrirAba('aba-consumo')">Consumo</button>
       <button class="aba" onclick="abrirAba('aba-entradas')">Entradas</button>
       <button class="aba" onclick="abrirAba('aba-saidas')">Saídas</button>
-      <button class="aba" onclick="abrirAba('aba-financeiro')">Financeiro</button>
       <button class="aba" onclick="abrirAba('aba-estoque')">Estoque Crítico</button>
       <button class="aba" onclick="abrirAba('aba-previsao')">Previsão</button>
     </div>
@@ -113,48 +113,6 @@
       <div id="tabela-saidas"></div>
     </div>
 
-    <!-- 🔥 Aba Financeiro -->
-    <div id="aba-financeiro" class="aba-conteudo" style="display:none">
-      <h2>💰 Financeiro</h2>
-
-      <div class="filtros">
-        <label>De:</label>
-        <input type="date" id="fin-data-inicio">
-        <label>Até:</label>
-        <input type="date" id="fin-data-fim">
-
-        <input type="text" id="fin-compra-id" placeholder="CompraID" list="lista-compra-fin" style="width:140px;">
-        <datalist id="lista-compra-fin"></datalist>
-        <select id="fin-fornecedor"></select>
-        <select id="fin-forma"></select>
-        <select id="fin-status"></select>
-
-        <button id="botao-atualizar-fin">🔄 Atualizar</button>
-        <button id="botao-limpar-fin">🧹 Limpar</button>
-        <button id="botao-exportar-csv-fin">📄 CSV</button>
-        <button id="botao-exportar-excel-fin">📊 Excel</button>
-      </div>
-
-      <div id="cards-financeiro" class="cards">
-        <div class="card"><strong>A pagar:</strong> <span id="total-pagar">-</span></div>
-        <div class="card"><strong>A receber:</strong> <span id="total-receber">-</span></div>
-        <div class="card"><strong>Pagos:</strong> <span id="total-pagos">-</span></div>
-        <div class="card"><strong>Recebidos:</strong> <span id="total-recebidos">-</span></div>
-      </div>
-
-      <div id="tabela-financeiro"></div>
-
-      <div id="modal-parcelas" class="modal">
-        <div class="modal-content">
-          <h3>Parcelas - Compra <span id="modal-compra-id"></span></h3>
-          <div id="parcelas-detalhes"></div>
-          <div style="margin-top:10px; text-align:right;">
-            <button onclick="fecharModalParcelas()">Fechar</button>
-          </div>
-        </div>
-      </div>
-      <div id="fundo-modal-parcelas" class="fundo-modal"></div>
-    </div>
 
 
     <!-- 🔥 Aba Estoque -->
@@ -250,10 +208,6 @@ background:#ffffffcc; z-index:2000; display:flex; align-items:center; justify-co
 <script type="module" src="js/relatorios/saidasTabela.js"></script>
 <script type="module" src="js/relatorios/saidasDados.js"></script>
 
-<script type="module" src="js/relatorios/financeiro.js"></script>
-<script type="module" src="js/relatorios/financeiroExportar.js"></script>
-<script type="module" src="js/relatorios/financeiroGraficos.js"></script>
-<script type="module" src="js/relatorios/financeiroTotais.js"></script>
 
 <script type="module" src="js/relatorios/estoque.js"></script>
 <script type="module" src="js/relatorios/estoqueExportar.js"></script>


### PR DESCRIPTION
## Summary
- create standalone `financeiro.html`
- remove Financeiro tab from `relatorios.html`
- update side menu links to include Financeiro page
- adjust financeiro table filters and totals
- fetch produtos in parcel modal
- drop unnecessary "A Receber" card

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_684d92699df4832b991a2d25c16295ee