### PR TITLE
Fix critical stock tab

### DIFF
--- a/js/relatorios/estoque.js
+++ b/js/relatorios/estoque.js
@@ -60,3 +60,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   atualizarTabelaEstoque();
 });
+
+// permite atualização ao abrir a aba
+window.atualizarTabelaEstoque = atualizarTabelaEstoque;

--- a/js/relatorios/estoqueTabela.js
+++ b/js/relatorios/estoqueTabela.js
@@ -30,17 +30,32 @@ export function dadosFiltradosEstoque() {
     const fornecedorMatch = fornecedorFiltro === "" || d.fornecedor === fornecedorFiltro;
     const loteMatch = !soLoteAtivo || d.quantidade > 0;
 
-    return nomeMatch && (estoqueCritico || validadeProxima) && tipoMatch && categoriaMatch && fornecedorMatch && loteMatch;
+    return nomeMatch && tipoMatch && categoriaMatch && fornecedorMatch && loteMatch;
   });
 }
 
 // 📦 Renderizar tabela
 export function gerarTabelaEstoque() {
   const lista = document.getElementById("tabela-estoque");
+  const diasValidade = parseInt(document.getElementById("input-dias-val").value) || 15;
   const filtrados = dadosFiltradosEstoque();
 
+  filtrados.sort((a, b) => {
+    const alertaA = a.quantidade <= a.quantidadeMinima || (a.diasParaVencer !== null && a.diasParaVencer <= diasValidade);
+    const alertaB = b.quantidade <= b.quantidadeMinima || (b.diasParaVencer !== null && b.diasParaVencer <= diasValidade);
+    if (alertaA !== alertaB) return alertaA ? -1 : 1;
+
+    const diasA = a.diasParaVencer ?? Infinity;
+    const diasB = b.diasParaVencer ?? Infinity;
+    if (diasA !== diasB) return diasA - diasB;
+
+    const diffA = (a.quantidade - a.quantidadeMinima);
+    const diffB = (b.quantidade - b.quantidadeMinima);
+    return diffA - diffB;
+  });
+
   if (filtrados.length === 0) {
-    lista.innerHTML = "<p>❌ Nenhum produto em alerta encontrado.</p>";
+    lista.innerHTML = "<p>❌ Nenhum produto encontrado.</p>";
     return;
   }
 

--- a/js/relatorios/estoqueTotais.js
+++ b/js/relatorios/estoqueTotais.js
@@ -1,6 +1,10 @@
 // estoqueTotais.js — Atualização dos cards
 
 export function atualizarCardsEstoque(dados) {
-  const totalAlertas = dados.length;
+  const diasValidade = parseInt(document.getElementById("input-dias-val").value) || 15;
+  const totalAlertas = dados.filter(d =>
+    d.quantidade <= d.quantidadeMinima ||
+    (d.diasParaVencer !== null && d.diasParaVencer <= diasValidade)
+  ).length;
   document.getElementById("card-estoque-alerta").textContent = totalAlertas;
 }

--- a/relatorios.html
+++ b/relatorios.html
@@ -272,6 +272,9 @@ background:#ffffffcc; z-index:2000; display:flex; align-items:center; justify-co
     document.querySelectorAll('.aba-conteudo').forEach(div => div.style.display = 'none');
     document.querySelector(`[onclick="abrirAba('${id}')"]`).classList.add('ativa');
     document.getElementById(id).style.display = 'block';
+    if(id === 'aba-estoque' && window.atualizarTabelaEstoque){
+      window.atualizarTabelaEstoque();
+    }
   }
 </script>
 


### PR DESCRIPTION
## Summary
- show all products in Critical Stock and sort alerts first
- recalc alert totals based on filter
- refresh stock table when switching to the Critical Stock tab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d929015bc832b9370d04010a6e95d