### PR TITLE
Fix previsao filter initialization

### DIFF
--- a/js/relatorios/previsao.js
+++ b/js/relatorios/previsao.js
@@ -37,7 +37,7 @@ export function limparFiltrosPrevisao() {
 }
 
 // 🚀 Inicialização
-document.addEventListener("DOMContentLoaded", () => {
+function initPrevisao() {
   document.getElementById("botao-atualizar-previsao")?.addEventListener("click", atualizarTabelaPrevisao);
   document.getElementById("botao-limpar-previsao")?.addEventListener("click", limparFiltrosPrevisao);
 
@@ -58,7 +58,13 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   atualizarTabelaPrevisao();
-});
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initPrevisao);
+} else {
+  initPrevisao();
+}
 
 // placeholder para solicitar reposição
 window.solicitarReposicao = function(id) {


### PR DESCRIPTION
## Summary
- adjust previsao.js initialization so filter events attach even if the DOM is already loaded

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d92979018832b9d3d71d24eaa9834