### PR TITLE
Implement header freezing for entries report

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -377,3 +377,12 @@ tr.critico {
 .btn-repor:hover {
   background-color: #d68910;
 }
+
+/* Cabeçalho fixo para a tabela de entradas */
+#tabela-entradas table.tabela-cabecalho-fixo thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #fafafa;
+}
+

--- a/js/relatorios/entradasTabela.js
+++ b/js/relatorios/entradasTabela.js
@@ -70,6 +70,7 @@ function aplicarFiltros() {
 
   html += '</tbody></table>';
   lista.innerHTML = html;
+  aplicarCabecalhoFixo();
   atualizarCardsEntradas(filtrados);
 }
 
@@ -109,4 +110,9 @@ export function limparFiltrosEntradas() {
   document.getElementById('filtro-data-inicio-entradas').value = '';
   document.getElementById('filtro-data-fim-entradas').value = '';
   aplicarFiltros();
+}
+
+function aplicarCabecalhoFixo() {
+  const tabela = document.querySelector('#tabela-entradas table');
+  if (tabela) tabela.classList.add('tabela-cabecalho-fixo');
 }


### PR DESCRIPTION
## Summary
- freeze table header in entries report
- apply sticky header style via JS and CSS

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f745203f4832b91499e204260e6ef