### PR TITLE
Hide CompraID column when empty

### DIFF
--- a/js/relatorios/entradasTabela.js
+++ b/js/relatorios/entradasTabela.js
@@ -36,6 +36,9 @@ function aplicarFiltros() {
     return;
   }
 
+  // Verifica se pelo menos um registro possui CompraID preenchido
+  const mostrarCompraId = filtrados.some(d => d.compraId && d.compraId !== '-' && String(d.compraId).trim() !== '');
+
   let html = `
     <table class="tabela">
       <thead>
@@ -45,7 +48,7 @@ function aplicarFiltros() {
           <th>Validade</th>
           <th>Preço Unitário</th>
           <th>Fornecedor</th>
-          <th>CompraID</th>
+          ${mostrarCompraId ? '<th>CompraID</th>' : ''}
           <th>Data</th>
         </tr>
       </thead>
@@ -62,7 +65,7 @@ function aplicarFiltros() {
         <td>${validade}</td>
         <td>${d.preco.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
         <td>${d.fornecedor}</td>
-        <td>${d.compraId}</td>
+        ${mostrarCompraId ? `<td>${d.compraId}</td>` : ''}
         <td>${data}</td>
       </tr>
     `;


### PR DESCRIPTION
## Summary
- dynamically hide `CompraID` column on Entradas report when filtered rows have no CompraID values

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f74626448832b875e2be07933f107