### PR TITLE
Add PDF export for Entradas report

### DIFF
--- a/js/relatorios/entradas.js
+++ b/js/relatorios/entradas.js
@@ -1,6 +1,6 @@
 import { carregarDadosEntradas } from './entradasDados.js';
 import { gerarTabelaEntradas, gerarFiltrosEntradas, limparFiltrosEntradas } from './entradasTabela.js';
-import { exportarEntradasExcel } from './entradasExportar.js';
+import { exportarEntradasExcel, exportarEntradasPDF } from './entradasExportar.js';
 import { mostrarSpinner, esconderSpinner } from '../utils.js';
 
 let dados = [];
@@ -21,5 +21,6 @@ export async function atualizarTabelaEntradas() {
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('botao-limpar-entradas')?.addEventListener('click', limparFiltrosEntradas);
   document.getElementById('botao-exportar-excel-entradas')?.addEventListener('click', () => exportarEntradasExcel(dados));
+  document.getElementById('botao-exportar-pdf-entradas')?.addEventListener('click', () => exportarEntradasPDF(dados));
   atualizarTabelaEntradas();
 });

--- a/js/relatorios/entradasExportar.js
+++ b/js/relatorios/entradasExportar.js
@@ -16,3 +16,46 @@ export async function exportarEntradasExcel(dados) {
   utils.book_append_sheet(workbook, worksheet, 'Entradas');
   writeFile(workbook, `relatorio_entradas_${Date.now()}.xlsx`);
 }
+
+export async function exportarEntradasPDF(dados) {
+  const { jsPDF } = await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.es.min.js');
+
+  const doc = new jsPDF();
+  doc.text('Relatório de Entradas', 14, 16);
+
+  const filtros = [];
+  const nome = document.getElementById('filtro-nome-entradas').value;
+  const fornecedor = document.getElementById('filtro-fornecedor-entradas').value;
+  const compra = document.getElementById('filtro-compra-entradas').value;
+  const dataInicio = document.getElementById('filtro-data-inicio-entradas').value;
+  const dataFim = document.getElementById('filtro-data-fim-entradas').value;
+
+  if (nome) filtros.push(`Produto: ${nome}`);
+  if (fornecedor) filtros.push(`Fornecedor: ${fornecedor}`);
+  if (compra) filtros.push(`Compra: ${compra}`);
+  if (dataInicio || dataFim) filtros.push(`Período: ${dataInicio || '-'} a ${dataFim || '-'}`);
+
+  let startY = 22;
+  filtros.forEach(f => {
+    doc.text(f, 14, startY);
+    startY += 6;
+  });
+
+  const linhas = dados.map(d => [
+    d.nome,
+    d.quantidade,
+    d.validade ? d.validade.toLocaleDateString('pt-BR') : '-',
+    d.preco.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }),
+    d.fornecedor,
+    d.compraId,
+    d.data ? d.data.toLocaleDateString('pt-BR') : '-'
+  ]);
+
+  doc.autoTable({
+    head: [['Produto', 'Quantidade', 'Validade', 'Preço Unitário', 'Fornecedor', 'CompraID', 'Data']],
+    body: linhas,
+    startY: startY + 2
+  });
+
+  doc.save(`relatorio_entradas_${Date.now()}.pdf`);
+}

--- a/relatorios.html
+++ b/relatorios.html
@@ -98,6 +98,7 @@
 
         <button id="botao-limpar-entradas">🧹 Limpar</button>
         <button id="botao-exportar-excel-entradas">📊 Excel</button>
+        <button id="botao-exportar-pdf-entradas">🖨️ PDF</button>
       </div>
 
       <div id="cards-entradas" class="cards">


### PR DESCRIPTION
## Summary
- add PDF export button to Entradas report
- implement `exportarEntradasPDF` using jsPDF
- wire the new button in the Entradas JS logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f7484aa80832b8c5e50fe45b01eb3