### PR TITLE
Add monthly entries chart

### DIFF
--- a/js/relatorios/entradasGraficos.js
+++ b/js/relatorios/entradasGraficos.js
@@ -1,0 +1,48 @@
+let grafico = null;
+
+export function gerarGraficoEntradas(dados) {
+  const canvas = document.getElementById('grafico-entradas');
+  if (!canvas) {
+    console.warn('⚠️ Canvas do gráfico de entradas não encontrado.');
+    return;
+  }
+  const ctx = canvas.getContext('2d');
+  if (!ctx || typeof Chart === 'undefined') {
+    console.warn('⚠️ Chart.js não está disponível ou contexto inválido.');
+    return;
+  }
+
+  if (grafico) grafico.destroy();
+
+  const mensal = {};
+  dados.forEach(d => {
+    if (d.data instanceof Date) {
+      const mes = `${d.data.getFullYear()}-${String(d.data.getMonth() + 1).padStart(2, '0')}`;
+      mensal[mes] = (mensal[mes] || 0) + (d.quantidade || 0);
+    }
+  });
+  const meses = Object.keys(mensal).sort();
+  const quantidades = meses.map(m => mensal[m]);
+
+  grafico = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: meses,
+      datasets: [{
+        label: 'Entradas',
+        data: quantidades,
+        backgroundColor: 'rgba(0,150,136,0.5)',
+        borderColor: 'rgba(0,150,136,1)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        legend: { display: false },
+        title: { display: true, text: 'Entradas por Mês' }
+      },
+      scales: { y: { beginAtZero: true } }
+    }
+  });
+}

--- a/js/relatorios/entradasTabela.js
+++ b/js/relatorios/entradasTabela.js
@@ -1,5 +1,6 @@
 import { normalizarTexto } from '../utils.js';
 import { atualizarCardsEntradas } from './entradasTotais.js';
+import { gerarGraficoEntradas } from './entradasGraficos.js';
 
 let dadosOriginais = [];
 
@@ -33,6 +34,7 @@ function aplicarFiltros() {
   if (filtrados.length === 0) {
     lista.innerHTML = '<p>❌ Nenhum dado encontrado.</p>';
     atualizarCardsEntradas([]);
+    gerarGraficoEntradas([]);
     return;
   }
 
@@ -71,6 +73,7 @@ function aplicarFiltros() {
   html += '</tbody></table>';
   lista.innerHTML = html;
   atualizarCardsEntradas(filtrados);
+  gerarGraficoEntradas(filtrados);
 }
 
 export function gerarFiltrosEntradas(dados) {

--- a/relatorios.html
+++ b/relatorios.html
@@ -106,6 +106,7 @@
       </div>
 
       <div id="tabela-entradas"></div>
+      <canvas id="grafico-entradas" style="max-height:300px; margin:20px 0;"></canvas>
     </div>
 
     <!-- 🔥 Aba Saídas -->
@@ -221,6 +222,7 @@ background:#ffffffcc; z-index:2000; display:flex; align-items:center; justify-co
 <script type="module" src="js/relatorios/entradasExportar.js"></script>
 <script type="module" src="js/relatorios/entradasTabela.js"></script>
 <script type="module" src="js/relatorios/entradasDados.js"></script>
+<script type="module" src="js/relatorios/entradasGraficos.js"></script>
 
 <script type="module" src="js/relatorios/saidas.js"></script>
 <script type="module" src="js/relatorios/saidasExportar.js"></script>


### PR DESCRIPTION
## Summary
- show quantity of entries per month in Entradas report
- display chart under the entries table
- update entries table script to update chart with filtered data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f748c628c832bb15e86fbc1f50ee4