### PR TITLE
Add average unit cost to entradas report

### DIFF
--- a/js/relatorios/entradasTotais.js
+++ b/js/relatorios/entradasTotais.js
@@ -1,7 +1,12 @@
 export function atualizarCardsEntradas(dados) {
   const totalQuantidade = dados.reduce((acc, cur) => acc + (cur.quantidade || 0), 0);
   const totalValor = dados.reduce((acc, cur) => acc + (cur.quantidade || 0) * (cur.preco || 0), 0);
+  const custoMedio = totalQuantidade ? totalValor / totalQuantidade : 0;
 
   document.getElementById('card-entradas-quantidade').textContent = totalQuantidade.toLocaleString('pt-BR');
   document.getElementById('card-entradas-valor').textContent = totalValor.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  const custoEl = document.getElementById('card-entradas-custo');
+  if (custoEl) {
+    custoEl.textContent = custoMedio.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  }
 }

--- a/relatorios.html
+++ b/relatorios.html
@@ -103,6 +103,7 @@
       <div id="cards-entradas" class="cards">
         <div class="card"><strong>Valor total:</strong> <span id="card-entradas-valor">-</span></div>
         <div class="card"><strong>Quantidade total:</strong> <span id="card-entradas-quantidade">-</span></div>
+        <div class="card"><strong>Custo médio/unid.:</strong> <span id="card-entradas-custo">-</span></div>
       </div>
 
       <div id="tabela-entradas"></div>


### PR DESCRIPTION
## Summary
- display weighted average unit cost in Entradas report
- show cost per unit alongside existing totals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f74933e34832ba74b8ff64f1dee0b