### PR TITLE
Add modal for entry details

### DIFF
--- a/js/relatorios/entradas.js
+++ b/js/relatorios/entradas.js
@@ -23,3 +23,25 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('botao-exportar-excel-entradas')?.addEventListener('click', () => exportarEntradasExcel(dados));
   atualizarTabelaEntradas();
 });
+
+// Modal de detalhes da entrada
+window.abrirModalDetalhesEntrada = function(id) {
+  const registro = dados.find(d => d.id === id);
+  if (!registro) return;
+
+  document.getElementById('detalhes-data').textContent = registro.data ? registro.data.toLocaleDateString('pt-BR') : '-';
+  document.getElementById('detalhes-produto').textContent = registro.nome;
+  document.getElementById('detalhes-quantidade').textContent = registro.quantidade;
+  document.getElementById('detalhes-validade').textContent = registro.validade ? registro.validade.toLocaleDateString('pt-BR') : '-';
+  document.getElementById('detalhes-fornecedor').textContent = registro.fornecedor;
+  document.getElementById('detalhes-observacoes').textContent = registro.observacao || '-';
+  document.getElementById('detalhes-id').textContent = registro.id;
+
+  document.getElementById('modal-detalhes-entrada').style.display = 'block';
+  document.getElementById('fundo-modal-detalhes-entrada').style.display = 'block';
+};
+
+window.fecharModalDetalhesEntrada = function() {
+  document.getElementById('modal-detalhes-entrada').style.display = 'none';
+  document.getElementById('fundo-modal-detalhes-entrada').style.display = 'none';
+};

--- a/js/relatorios/entradasDados.js
+++ b/js/relatorios/entradasDados.js
@@ -18,6 +18,7 @@ export async function carregarDadosEntradas() {
       preco: Number(d.precoUnitario) || 0,
       compraId: d.compraId || '-',
       data: d.dataMovimentacao?.toDate() || null,
+      observacao: d.observacao || '',
       nomeBusca: normalizarTexto(d.nomeProduto || '')
     };
   });

--- a/js/relatorios/entradasTabela.js
+++ b/js/relatorios/entradasTabela.js
@@ -47,6 +47,7 @@ function aplicarFiltros() {
           <th>Fornecedor</th>
           <th>CompraID</th>
           <th>Data</th>
+          <th>Detalhes</th>
         </tr>
       </thead>
       <tbody>
@@ -64,6 +65,7 @@ function aplicarFiltros() {
         <td>${d.fornecedor}</td>
         <td>${d.compraId}</td>
         <td>${data}</td>
+        <td><button onclick="abrirModalDetalhesEntrada('${d.id}')">Ver Detalhes</button></td>
       </tr>
     `;
   });

--- a/relatorios.html
+++ b/relatorios.html
@@ -106,6 +106,23 @@
       </div>
 
       <div id="tabela-entradas"></div>
+
+      <div id="modal-detalhes-entrada" class="modal">
+        <div class="modal-content">
+          <h3>Detalhes da Entrada</h3>
+          <p><strong>Data:</strong> <span id="detalhes-data"></span></p>
+          <p><strong>Produto:</strong> <span id="detalhes-produto"></span></p>
+          <p><strong>Quantidade:</strong> <span id="detalhes-quantidade"></span></p>
+          <p><strong>Validade:</strong> <span id="detalhes-validade"></span></p>
+          <p><strong>Fornecedor:</strong> <span id="detalhes-fornecedor"></span></p>
+          <p><strong>Observações:</strong> <span id="detalhes-observacoes"></span></p>
+          <p><strong>ID Interno:</strong> <span id="detalhes-id"></span></p>
+          <div style="text-align:right; margin-top:10px;">
+            <button onclick="fecharModalDetalhesEntrada()">Fechar</button>
+          </div>
+        </div>
+      </div>
+      <div id="fundo-modal-detalhes-entrada" class="fundo-modal" onclick="fecharModalDetalhesEntrada()"></div>
     </div>
 
     <!-- 🔥 Aba Saídas -->


### PR DESCRIPTION
## Summary
- add observacao field to report entry data
- show "Ver Detalhes" column with button on entries table
- implement modal logic to display entry details
- include modal markup in the report page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f749ed638832ba8dfcc7931e585e0