### PR TITLE
Add product change history

### DIFF
--- a/js/historico.js
+++ b/js/historico.js
@@ -1,0 +1,35 @@
+import { db } from './firebaseConfig.js';
+import { collection, addDoc, Timestamp, query, orderBy, getDocs } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+
+const auth = getAuth();
+
+export async function registrarHistorico(produtoId, campo, de, para) {
+  try {
+    if (de === para) return;
+    const usuario = auth.currentUser?.email || 'desconhecido';
+    await addDoc(collection(db, 'produtos', produtoId, 'historico'), {
+      campo,
+      de,
+      para,
+      usuario,
+      data: Timestamp.now()
+    });
+  } catch (e) {
+    console.error('Erro ao registrar histórico:', e);
+  }
+}
+
+export async function carregarHistorico(produtoId) {
+  try {
+    const q = query(
+      collection(db, 'produtos', produtoId, 'historico'),
+      orderBy('data', 'desc')
+    );
+    const snap = await getDocs(q);
+    return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+  } catch (e) {
+    console.error('Erro ao carregar histórico:', e);
+    return [];
+  }
+}

--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -14,6 +14,7 @@ import {
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
 import { mostrarErro, normalizarTexto } from './utils.js';
+import { registrarHistorico } from './historico.js';
 
 let produtoCadastroAtual = null;
 let dadosFinanceiroAtual = null;
@@ -187,6 +188,7 @@ window.confirmarEntradaEstoque = async function () {
     // 🔸 Atualiza o estoque
     const novaQuantidade = (produto.quantidade || 0) + quantidade;
     await updateDoc(produtoRef, { quantidade: novaQuantidade });
+    await registrarHistorico(produtoCadastroAtual.id, 'quantidade', produto.quantidade || 0, novaQuantidade);
 
     // 🔸 Registra a movimentação
     await addDoc(collection(db, "movimentacoes"), {

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -13,6 +13,7 @@ import {
   mostrarSpinner,
   esconderSpinner
 } from './utils.js';
+import { registrarHistorico } from './historico.js';
 
 import {
   abrirModalConfirmacao,
@@ -406,6 +407,7 @@ document.getElementById("form-movimentacao").addEventListener("submit", async (e
     async () => {
       try {
         await updateDoc(produtoRef, { quantidade: novaQuantidade });
+        await registrarHistorico(produtoEncontrado.id, 'quantidade', produto.quantidade || 0, novaQuantidade);
 
         const dataTimestamp = Timestamp.fromDate(dataMov);
 

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -15,6 +15,8 @@ import {
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { ref as storageRef, uploadString } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js";
 
+import { registrarHistorico, carregarHistorico } from './historico.js';
+
 import {
   abrirModalProdutoExiste
 } from './modais.js';
@@ -65,6 +67,7 @@ function formatarDataInput(data) {
 let listenerFormulario = null;
 let produtosCache = [];
 let editandoProdutoId = null;
+let produtoEmEdicao = null;
 
 // ==========================
 // 🔥 Carregar Produtos
@@ -144,7 +147,10 @@ function renderizarTabela(produtos, termo = "") {
         <td>${dataValidade}</td>
         <td>${p.fornecedor || "-"}</td>
         <td>${p.localizacao || "-"}</td>
-        <td><button onclick="editarProduto('${p.id}')">✏️ Editar</button></td>
+        <td>
+          <button onclick="verDetalhes('${p.id}')">👁️ Detalhes</button>
+          <button onclick="editarProduto('${p.id}')">✏️ Editar</button>
+        </td>
       </tr>
     `;
   });
@@ -274,6 +280,7 @@ window.editarProduto = async function (id) {
 
     const p = docSnap.data();
     editandoProdutoId = id;
+    produtoEmEdicao = p;
 
     document.getElementById("nome").value = p.nome || "";
     document.getElementById("categoria").value = p.categoria || "";
@@ -329,6 +336,16 @@ window.editarProduto = async function (id) {
       };
 
       await updateDoc(docRef, atualizados);
+
+      const conv = v => {
+        if (v?.toDate) return v.toDate().toISOString();
+        return v ?? '';
+      };
+      await registrarHistorico(editandoProdutoId, 'quantidade', produtoEmEdicao.quantidade, atualizados.quantidade);
+      await registrarHistorico(editandoProdutoId, 'precoCompra', produtoEmEdicao.precoCompra, atualizados.precoCompra);
+      await registrarHistorico(editandoProdutoId, 'validade', conv(produtoEmEdicao.validade), conv(atualizados.validade));
+      await registrarHistorico(editandoProdutoId, 'fornecedor', produtoEmEdicao.fornecedor, atualizados.fornecedor);
+
       await gerarESalvarCSV();
 
       mostrarMensagem("✅ Alterações salvas com sucesso!");
@@ -452,4 +469,63 @@ if (campoDataEntrada && !campoDataEntrada.value) {
     .split("T")[0];
   campoDataEntrada.value = hoje;
 }
+
+// ==========================
+// 🔥 Ver Detalhes do Produto
+// ==========================
+window.verDetalhes = async function(id) {
+  await executarComSpinner(async () => {
+    const docRef = doc(db, 'produtos', id);
+    const snap = await getDoc(docRef);
+    if (!snap.exists()) {
+      mostrarErro('❌ Produto não encontrado.');
+      return;
+    }
+
+    const p = snap.data();
+    document.getElementById('det-nome').textContent = p.nome || '-';
+    document.getElementById('det-categoria').textContent = p.categoria || '-';
+    document.getElementById('det-quantidade').textContent = p.quantidade ?? '-';
+    document.getElementById('det-preco').textContent =
+      p.precoCompra !== undefined && p.precoCompra !== null ? p.precoCompra : '-';
+    document.getElementById('det-fornecedor').textContent = p.fornecedor || '-';
+    document.getElementById('det-validade').textContent = formatarData(p.validade);
+
+    const historico = await carregarHistorico(id);
+    const lista = document.getElementById('lista-historico');
+    if (lista) {
+      if (historico.length === 0) {
+        lista.innerHTML = '<p>Sem alterações registradas.</p>';
+      } else {
+        let html = `<table class="tabela"><thead><tr><th>Campo</th><th>De</th><th>Para</th><th>Usuário</th><th>Data</th></tr></thead><tbody>`;
+        historico.forEach(h => {
+          const data = h.data?.toDate ? h.data.toDate() : new Date(h.data);
+          const dataStr = data.toLocaleString('pt-BR');
+          html += `<tr><td>${h.campo}</td><td>${h.de ?? '-'}</td><td>${h.para ?? '-'}</td><td>${h.usuario || '-'}</td><td>${dataStr}</td></tr>`;
+        });
+        html += '</tbody></table>';
+        lista.innerHTML = html;
+      }
+    }
+
+    document.getElementById('modal-detalhes-produto').style.display = 'block';
+    document.getElementById('fundo-modal-detalhes-produto').style.display = 'block';
+    mostrarAbaDetalhes();
+  });
+};
+
+window.fecharModalDetalhes = function() {
+  document.getElementById('modal-detalhes-produto').style.display = 'none';
+  document.getElementById('fundo-modal-detalhes-produto').style.display = 'none';
+};
+
+window.mostrarAbaDetalhes = function() {
+  document.getElementById('aba-detalhes').style.display = 'block';
+  document.getElementById('aba-historico').style.display = 'none';
+};
+
+window.mostrarAbaHistorico = function() {
+  document.getElementById('aba-detalhes').style.display = 'none';
+  document.getElementById('aba-historico').style.display = 'block';
+};
 

--- a/produtos.html
+++ b/produtos.html
@@ -188,5 +188,33 @@
     </div>
   </div>
 
+  <!-- 🔧 Fundo Modal Detalhes -->
+  <div id="fundo-modal-detalhes-produto" class="fundo-modal"></div>
+
+  <!-- ✅ Modal Detalhes do Produto -->
+  <div id="modal-detalhes-produto" class="modal">
+    <div class="modal-content">
+      <h3>Detalhes do Produto</h3>
+      <div>
+        <button onclick="mostrarAbaDetalhes()">Detalhes</button>
+        <button onclick="mostrarAbaHistorico()">Histórico</button>
+      </div>
+      <div id="aba-detalhes" style="margin-top:10px;">
+        <p><strong>Nome:</strong> <span id="det-nome"></span></p>
+        <p><strong>Categoria:</strong> <span id="det-categoria"></span></p>
+        <p><strong>Quantidade:</strong> <span id="det-quantidade"></span></p>
+        <p><strong>Preço:</strong> <span id="det-preco"></span></p>
+        <p><strong>Fornecedor:</strong> <span id="det-fornecedor"></span></p>
+        <p><strong>Validade:</strong> <span id="det-validade"></span></p>
+      </div>
+      <div id="aba-historico" style="display:none; margin-top:10px;">
+        <div id="lista-historico"></div>
+      </div>
+      <div style="margin-top:15px; text-align:right;">
+        <button onclick="fecharModalDetalhes()">Fechar</button>
+      </div>
+    </div>
+  </div>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- track product updates in new `historico` subcollection
- show a `Ver Detalhes` modal with historical changes
- log quantity changes from entry/exit operations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f74a541ec832bad63bbeeab4008a2