### PR TITLE
Fix quantity double counting on product registration

### DIFF
--- a/js/produtos.js
+++ b/js/produtos.js
@@ -219,7 +219,7 @@ async function adicionarProduto() {
           nome,
           nomeBusca: nomeNormalizado,
           categoria,
-          quantidade,
+          quantidade: 0, // quantidade será adicionada via entrada
           quantidadeMinima,
           validade: isNaN(validade.getTime()) ? null : Timestamp.fromDate(validade),
           dataEntrada: isNaN(dataEntrada.getTime()) ? null : Timestamp.fromDate(dataEntrada),


### PR DESCRIPTION
## Summary
- prevent duplicate quantity when registering a new product

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852dbbfdc18832b8c8d69e68ec91dc9