### PR TITLE
Fix product edit triggering new entry modal

### DIFF
--- a/js/produtos.js
+++ b/js/produtos.js
@@ -460,6 +460,10 @@ const btn = document.querySelector("#form-produto button[type='submit']");
 if (form && btn) {
   form.addEventListener("submit", (e) => {
     e.preventDefault();
+    // se houver um produto em edição, o listener específico de edição irá tratar
+    if (editandoProdutoId) {
+      return;
+    }
     adicionarProduto();
   });
 }


### PR DESCRIPTION
## Summary
- avoid invoking new-product logic when editing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68541f2762cc832b8a6b57f013e13fe2