### PR TITLE
Implement multi-company data isolation

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -4,6 +4,7 @@ import {
   onAuthStateChanged,
   signOut
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
+import { getEmpresaIdDoUsuario } from './firebaseConfig.js';
 
 // 🔐 Firebase config (a mesma que você já está usando)
 const firebaseConfig = {
@@ -22,6 +23,9 @@ const auth = getAuth(app);
 onAuthStateChanged(auth, (user) => {
   if (!user) {
     window.location.href = "index.html"; // Redireciona para login
+  } else {
+    // Carrega e mantém em cache o empresaId do usuário
+    getEmpresaIdDoUsuario();
   }
 });
 

--- a/js/firebaseConfig.js
+++ b/js/firebaseConfig.js
@@ -1,6 +1,6 @@
 // js/firebaseConfig.js
 import { initializeApp, getApps } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js";
-import { getFirestore } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
+import { getFirestore, doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { getAuth } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
 import { getStorage } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js";
 
@@ -21,3 +21,36 @@ const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const auth = getAuth(app);
 export const storage = getStorage(app);
+
+// 🏢 Empresa vinculada ao usuário logado
+let empresaIdCache = null;
+
+/**
+ * Retorna o empresaId do usuário logado. Se não existir na coleção
+ * `usuarios`, um registro básico é criado automaticamente usando o UID.
+ */
+export async function getEmpresaIdDoUsuario() {
+  if (empresaIdCache) return empresaIdCache;
+  const user = auth.currentUser;
+  if (!user) return null;
+  try {
+    const ref = doc(db, 'usuarios', user.uid);
+    const snap = await getDoc(ref);
+    if (snap.exists()) {
+      const data = snap.data() || {};
+      empresaIdCache = data.empresaId || user.uid;
+    } else {
+      empresaIdCache = user.uid;
+      await setDoc(ref, {
+        uid: user.uid,
+        empresaId: empresaIdCache,
+        nome: user.displayName || user.email || '',
+        tipo: 'admin'
+      });
+    }
+  } catch (e) {
+    console.error('Erro ao obter empresaId:', e);
+    empresaIdCache = user.uid;
+  }
+  return empresaIdCache;
+}

--- a/js/historico.js
+++ b/js/historico.js
@@ -1,4 +1,4 @@
-import { db } from './firebaseConfig.js';
+import { db, getEmpresaIdDoUsuario } from './firebaseConfig.js';
 import { collection, addDoc, Timestamp, query, orderBy, getDocs } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 
@@ -8,7 +8,8 @@ export async function registrarHistorico(produtoId, campo, de, para) {
   try {
     if (de === para) return;
     const usuario = auth.currentUser?.email || 'desconhecido';
-    await addDoc(collection(db, 'produtos', produtoId, 'historico'), {
+    const empresaId = await getEmpresaIdDoUsuario();
+    await addDoc(collection(db, 'empresas', empresaId, 'produtos', produtoId, 'historico'), {
       campo,
       de,
       para,
@@ -22,8 +23,9 @@ export async function registrarHistorico(produtoId, campo, de, para) {
 
 export async function carregarHistorico(produtoId) {
   try {
+    const empresaId = await getEmpresaIdDoUsuario();
     const q = query(
-      collection(db, 'produtos', produtoId, 'historico'),
+      collection(db, 'empresas', empresaId, 'produtos', produtoId, 'historico'),
       orderBy('data', 'desc')
     );
     const snap = await getDocs(q);

--- a/js/main.js
+++ b/js/main.js
@@ -1,20 +1,6 @@
 // Importa os módulos do Firebase
-import { initializeApp, getApps } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js";
-import { getAuth, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
-
-// Suas credenciais do Firebase
-const firebaseConfig = {
-  apiKey: "AIzaSyDlFchQ4jpvTtaR5jRRbEmmzYiXEHDlRGM",
-  authDomain: "zelia-1.firebaseapp.com",
-  projectId: "zelia-1",
-  storageBucket: "zelia-1.appspot.com",
-  messagingSenderId: "276186984066",
-  appId: "1:276186984066:web:af8d09733e7f179aad4e9b"
-};
-
-// Inicializa o Firebase
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
-const auth = getAuth(app);
+import { auth, getEmpresaIdDoUsuario } from './firebaseConfig.js';
+import { signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
 
 // Função de login
 window.login = function () {
@@ -27,8 +13,10 @@ window.login = function () {
     .then((userCredential) => {
       // Sucesso no login
       console.log("Login realizado:", userCredential.user);
-      alert("Login realizado com sucesso!");
-      window.location.href = "dashboard.html"; // Redireciona para o painel
+      getEmpresaIdDoUsuario().then(() => {
+        alert("Login realizado com sucesso!");
+        window.location.href = "dashboard.html"; // Redireciona para o painel
+      });
     })
     .catch((error) => {
       // Erro no login

--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -1,6 +1,6 @@
 // modalEntrada.js - Controle do modal de entrada + financeiro
 
-import { db } from "./firebaseConfig.js";
+import { db, getEmpresaIdDoUsuario } from "./firebaseConfig.js";
 import {
   collection,
   addDoc,
@@ -22,8 +22,9 @@ let dadosFinanceiroAtual = null;
 // Calcula a média de preços das entradas anteriores de um produto
 async function calcularPrecoMedioEntradas(produtoId) {
   try {
+    const empresaId = await getEmpresaIdDoUsuario();
     const q = query(
-      collection(db, 'movimentacoes'),
+      collection(db, 'empresas', empresaId, 'movimentacoes'),
       where('produtoId', '==', produtoId),
       where('tipo', '==', 'entrada')
     );
@@ -60,7 +61,8 @@ export async function abrirModalEntrada(produto) {
     const lista = document.getElementById("lista-compra-id");
     if (lista) {
       lista.innerHTML = "";
-      const comprasSnap = await getDocs(collection(db, "financeiro"));
+      const empresaId = await getEmpresaIdDoUsuario();
+      const comprasSnap = await getDocs(collection(db, "empresas", empresaId, "financeiro"));
       const ids = new Set();
       comprasSnap.forEach(docSnap => {
         const d = docSnap.data();
@@ -107,7 +109,8 @@ export function fecharModalEntrada() {
 async function preencherDadosFinanceiro(compraId) {
   if (!compraId) return;
   try {
-    const q = query(collection(db, "financeiro"), where("compraId", "==", compraId));
+    const empresaId = await getEmpresaIdDoUsuario();
+    const q = query(collection(db, "empresas", empresaId, "financeiro"), where("compraId", "==", compraId));
     const snap = await getDocs(q);
     if (!snap.empty) {
       dadosFinanceiroAtual = snap.docs[0].data();
@@ -181,7 +184,8 @@ window.confirmarEntradaEstoque = async function () {
       return;
     }
 
-    const produtoRef = doc(db, "produtos", produtoCadastroAtual.id);
+    const empresaId = await getEmpresaIdDoUsuario();
+    const produtoRef = doc(db, "empresas", empresaId, "produtos", produtoCadastroAtual.id);
     const produtoSnap = await getDoc(produtoRef);
 
     if (!produtoSnap.exists()) {
@@ -232,7 +236,7 @@ window.confirmarEntradaEstoque = async function () {
     await registrarHistorico(produtoCadastroAtual.id, 'quantidade', produto.quantidade || 0, novaQuantidade);
 
     // 🔸 Registra a movimentação
-    await addDoc(collection(db, "movimentacoes"), {
+    await addDoc(collection(db, "empresas", empresaId, "movimentacoes"), {
       produtoId: produtoCadastroAtual.id,
       nomeProduto: produto.nome,
       nomeBusca: normalizarTexto(produto.nome),
@@ -252,12 +256,12 @@ window.confirmarEntradaEstoque = async function () {
     });
     
     // 🔸 Registra ou atualiza o financeiro
-    const finQuery = query(collection(db, "financeiro"), where("compraId", "==", compraId));
+    const finQuery = query(collection(db, "empresas", empresaId, "financeiro"), where("compraId", "==", compraId));
     const finSnap = await getDocs(finQuery);
 
     if (!finSnap.empty) {
       const existing = finSnap.docs[0];
-      const finRef = doc(db, "financeiro", existing.id);
+      const finRef = doc(db, "empresas", empresaId, "financeiro", existing.id);
       const finData = existing.data();
       const parcelasExistentes = Array.isArray(finData.parcelas) ? finData.parcelas : [];
 
@@ -277,7 +281,7 @@ window.confirmarEntradaEstoque = async function () {
         parcelas: parcelasAtualizadas
       });
     } else {
-      await addDoc(collection(db, "financeiro"), {
+      await addDoc(collection(db, "empresas", empresaId, "financeiro"), {
         tipo: "pagar",
         fornecedorOuCliente: produto.fornecedor || "Fornecedor não informado",
         descricao: `Compra de ${quantidade} ${produto.unidadeMedida || "unidade(s)"} de ${produto.nome}`,

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -1,6 +1,6 @@
 // movimentacoes.js — Gerenciamento de entradas e saídas de produtos no sistema Zélia.
 
-import { db } from "./firebaseConfig.js";
+import { db, getEmpresaIdDoUsuario } from "./firebaseConfig.js";
 import {
   collection, getDocs, addDoc, query, where, doc, updateDoc, orderBy, Timestamp, getDoc
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
@@ -41,7 +41,8 @@ async function carregarMovimentacoes() {
     const lista = document.getElementById("lista-movimentacoes");
     lista.innerHTML = "<p>Carregando movimentações...</p>";
 
-    const q = query(collection(db, "movimentacoes"), orderBy("dataMovimentacao", "desc"));
+    const empresaId = await getEmpresaIdDoUsuario();
+    const q = query(collection(db, "empresas", empresaId, "movimentacoes"), orderBy("dataMovimentacao", "desc"));
     const snapshot = await getDocs(q);
     movimentacoesCache = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 
@@ -68,7 +69,8 @@ document.addEventListener("DOMContentLoaded", () => {
 // 🔥 Carregar Produtos (para autocomplete)
 // =========================
 async function carregarProdutos() {
-  const snapshot = await getDocs(collection(db, "produtos"));
+  const empresaId = await getEmpresaIdDoUsuario();
+  const snapshot = await getDocs(collection(db, "empresas", empresaId, "produtos"));
   produtosCache = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 
   // Agrupa os produtos por nome normalizado
@@ -94,8 +96,9 @@ async function obterPrecoDaValidade(nome, validadeStr) {
   const validadeTs = Timestamp.fromDate(dataVal);
 
   try {
+    const empresaId = await getEmpresaIdDoUsuario();
     const q = query(
-      collection(db, "movimentacoes"),
+      collection(db, "empresas", empresaId, "movimentacoes"),
       where("nomeBusca", "==", nomeNormalizado),
       where("tipo", "==", "entrada"),
       where("validade", "==", validadeTs)
@@ -303,8 +306,9 @@ selectValidadeSaida.innerHTML = "";
   if (tipo !== "saida" || nome.length < 2) return;
 
   const nomeNormalizado = normalizarTexto(nome);
+  const empresaId = await getEmpresaIdDoUsuario();
   const snapshot = await getDocs(query(
-    collection(db, "movimentacoes"),
+    collection(db, "empresas", empresaId, "movimentacoes"),
     where("nomeBusca", "==", nomeNormalizado)
   ));
 
@@ -417,7 +421,8 @@ document.getElementById("form-movimentacao").addEventListener("submit", async (e
     return;
   }
 
-  const produtoRef = doc(db, "produtos", produtoEncontrado.id);
+  const empresaId = await getEmpresaIdDoUsuario();
+  const produtoRef = doc(db, "empresas", empresaId, "produtos", produtoEncontrado.id);
   const produtoSnap = await getDoc(produtoRef);
   const produto = produtoSnap.data();
 
@@ -455,7 +460,7 @@ document.getElementById("form-movimentacao").addEventListener("submit", async (e
 
         const dataTimestamp = Timestamp.fromDate(dataMov);
 
-        await addDoc(collection(db, "movimentacoes"), {
+        await addDoc(collection(db, "empresas", empresaId, "movimentacoes"), {
           produtoId: produtoEncontrado.id,
           nomeProduto: produto.nome,
           nomeBusca: normalizarTexto(produto.nome),
@@ -542,7 +547,8 @@ function renderizarTabela(movimentacoes, termo = "") {
 // 🔥 Editar Movimentação
 // ==========================
 window.editarMovimentacao = async function (id) {
-  const docRef = doc(db, "movimentacoes", id);
+  const empresaId = await getEmpresaIdDoUsuario();
+  const docRef = doc(db, "empresas", empresaId, "movimentacoes", id);
   const docSnap = await getDoc(docRef);
 
   if (!docSnap.exists()) {

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -1,6 +1,6 @@
 // produtos.js — Gerenciamento de produtos para o sistema Zélia.
 
-import { db, storage } from "./firebaseConfig.js";
+import { db, storage, getEmpresaIdDoUsuario } from "./firebaseConfig.js";
 import {
   collection,
   getDocs,
@@ -79,7 +79,8 @@ async function carregarProdutos() {
     const lista = document.getElementById("lista-produtos");
     lista.innerHTML = "<p>Carregando produtos...</p>";
 
-    const q = query(collection(db, "produtos"), orderBy("dataEntrada", "desc"));
+    const empresaId = await getEmpresaIdDoUsuario();
+    const q = query(collection(db, "empresas", empresaId, "produtos"), orderBy("dataEntrada", "desc"));
     const snapshot = await getDocs(q);
 
     // console.log(`✅ Produtos carregados: ${snapshot.docs.length}`);
@@ -246,7 +247,8 @@ async function adicionarProduto() {
       const nomeNormalizado = normalizarTexto(nome);
       // console.log("🔎 Nome normalizado:", nomeNormalizado);
 
-      const q = query(collection(db, "produtos"), where("nomeBusca", "==", nomeNormalizado));
+      const empresaId = await getEmpresaIdDoUsuario();
+      const q = query(collection(db, "empresas", empresaId, "produtos"), where("nomeBusca", "==", nomeNormalizado));
       const snapshot = await getDocs(q);
 
       if (!snapshot.empty) {
@@ -256,7 +258,7 @@ async function adicionarProduto() {
       }
 
       try {
-        const docRef = await addDoc(collection(db, "produtos"), {
+        const docRef = await addDoc(collection(db, "empresas", empresaId, "produtos"), {
           nome,
           nomeBusca: nomeNormalizado,
           categoria,
@@ -312,7 +314,8 @@ async function adicionarProduto() {
 // ==========================
 window.editarProduto = async function (id) {
   await executarComSpinner(async () => {
-    const ref = doc(db, 'produtos', id);
+    const empresaId = await getEmpresaIdDoUsuario();
+    const ref = doc(db, 'empresas', empresaId, 'produtos', id);
     const snap = await getDoc(ref);
 
     if (!snap.exists()) {
@@ -412,7 +415,8 @@ async function salvarAlteracoesProduto() {
 // 🔥 Carregar Sugestões
 // ==========================
 async function carregarSugestoes() {
-  const snapshot = await getDocs(collection(db, "produtos"));
+  const empresaId = await getEmpresaIdDoUsuario();
+  const snapshot = await getDocs(collection(db, "empresas", empresaId, "produtos"));
   const categorias = new Set();
   const fornecedores = new Set();
 
@@ -439,7 +443,8 @@ document.getElementById("nome").addEventListener("blur", function () {
     const termo = normalizarTexto(input.value.trim());
     if (!termo) return;
 
-    const q = query(collection(db, "produtos"), where("nomeBusca", "==", termo));
+    const empresaId = await getEmpresaIdDoUsuario();
+    const q = query(collection(db, "empresas", empresaId, "produtos"), where("nomeBusca", "==", termo));
     const snapshot = await getDocs(q);
 
     if (!snapshot.empty) {
@@ -459,7 +464,8 @@ document.getElementById("nome").addEventListener("blur", function () {
 // 🔥 Gerar e Salvar CSV
 // ==========================
 async function gerarESalvarCSV() {
-  const snapshot = await getDocs(collection(db, "produtos"));
+  const empresaId = await getEmpresaIdDoUsuario();
+  const snapshot = await getDocs(collection(db, "empresas", empresaId, "produtos"));
   const produtos = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 
   if (!produtos.length) return;
@@ -528,7 +534,8 @@ if (campoDataEntrada && !campoDataEntrada.value) {
 // ==========================
 window.verDetalhes = async function(id) {
   await executarComSpinner(async () => {
-    const docRef = doc(db, 'produtos', id);
+    const empresaId = await getEmpresaIdDoUsuario();
+    const docRef = doc(db, 'empresas', empresaId, 'produtos', id);
     const snap = await getDoc(docRef);
     if (!snap.exists()) {
       mostrarErro('❌ Produto não encontrado.');

--- a/js/relatorios/consumoDados.js
+++ b/js/relatorios/consumoDados.js
@@ -1,10 +1,11 @@
-import { db } from '../firebaseConfig.js';
+import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where, orderBy } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { normalizarTexto } from '../utils.js';
 
 export async function carregarDadosConsumo() {
+  const empresaId = await getEmpresaIdDoUsuario();
   const snapshot = await getDocs(
-    query(collection(db, "movimentacoes"), where("tipo", "==", "saida"), orderBy("dataMovimentacao", "desc"))
+    query(collection(db, "empresas", empresaId, "movimentacoes"), where("tipo", "==", "saida"), orderBy("dataMovimentacao", "desc"))
   );
 
   return snapshot.docs.map(doc => {

--- a/js/relatorios/entradasDados.js
+++ b/js/relatorios/entradasDados.js
@@ -1,10 +1,11 @@
-import { db } from '../firebaseConfig.js';
+import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where, orderBy } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { normalizarTexto } from '../utils.js';
 
 export async function carregarDadosEntradas() {
+  const empresaId = await getEmpresaIdDoUsuario();
   const snapshot = await getDocs(
-    query(collection(db, 'movimentacoes'), where('tipo', '==', 'entrada'), orderBy('dataMovimentacao', 'desc'))
+    query(collection(db, 'empresas', empresaId, 'movimentacoes'), where('tipo', '==', 'entrada'), orderBy('dataMovimentacao', 'desc'))
   );
 
   return snapshot.docs.map(doc => {

--- a/js/relatorios/estoqueDados.js
+++ b/js/relatorios/estoqueDados.js
@@ -1,12 +1,13 @@
 // estoqueDados.js — Buscar dados de estoque (alertas)
 
-import { db } from '../firebaseConfig.js';
+import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, orderBy } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { normalizarTexto } from '../utils.js';
 
 export async function carregarDadosEstoque(diasValidade = 30) {
+  const empresaId = await getEmpresaIdDoUsuario();
   const snapshot = await getDocs(
-    query(collection(db, "produtos"), orderBy("nome"))
+    query(collection(db, "empresas", empresaId, "produtos"), orderBy("nome"))
   );
 
   const hoje = new Date();

--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -4,7 +4,7 @@ import { carregarDadosFinanceiro } from './financeiroDados.js';
 import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro } from './financeiroTabela.js';
 import { exportarFinanceiroCSV, exportarFinanceiroExcel } from './financeiroExportar.js';
 import { mostrarSpinner, esconderSpinner } from '../utils.js';
-import { db } from '../firebaseConfig.js';
+import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
 let dadosFinanceiro = [];
@@ -67,7 +67,8 @@ window.abrirModalParcelas = async function (compraId) {
 
   // Produtos relacionados
   try {
-    const q = query(collection(db, 'movimentacoes'), where('compraId', '==', compraId), where('tipo', '==', 'entrada'));
+    const empresaId = await getEmpresaIdDoUsuario();
+    const q = query(collection(db, 'empresas', empresaId, 'movimentacoes'), where('compraId', '==', compraId), where('tipo', '==', 'entrada'));
     const snap = await getDocs(q);
     if (!snap.empty) {
       html += '<h4>Produtos</h4><table class="tabela"><thead><tr><th>Produto</th><th>Qtd</th><th>Preço</th></tr></thead><tbody>';

--- a/js/relatorios/financeiroDados.js
+++ b/js/relatorios/financeiroDados.js
@@ -1,6 +1,6 @@
 // financeiroDados.js — Buscar dados do Firestore
 
-import { db } from '../firebaseConfig.js';
+import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, orderBy } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
 export async function carregarDadosFinanceiro(periodoMeses = 3) {
@@ -8,8 +8,9 @@ export async function carregarDadosFinanceiro(periodoMeses = 3) {
   const dataLimite = new Date();
   dataLimite.setMonth(hoje.getMonth() - periodoMeses);
 
+  const empresaId = await getEmpresaIdDoUsuario();
   const snapshot = await getDocs(
-    query(collection(db, "financeiro"), orderBy("dataLancamento", "desc"))
+    query(collection(db, "empresas", empresaId, "financeiro"), orderBy("dataLancamento", "desc"))
   );
 
   return snapshot.docs

--- a/js/relatorios/previsaoDados.js
+++ b/js/relatorios/previsaoDados.js
@@ -1,6 +1,6 @@
 // previsaoDados.js — Dados da previsão de esgotamento
 
-import { db } from '../firebaseConfig.js';
+import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where, orderBy, Timestamp } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { normalizarTexto } from '../utils.js';
 
@@ -9,9 +9,10 @@ export async function carregarDadosPrevisao(periodoMeses = 3) {
   const dataInicio = new Date();
   dataInicio.setMonth(dataInicio.getMonth() - periodoMeses);
 
+  const empresaId = await getEmpresaIdDoUsuario();
   const movSnap = await getDocs(
     query(
-      collection(db, "movimentacoes"),
+      collection(db, "empresas", empresaId, "movimentacoes"),
       where("tipo", "==", "saida"),
       where("dataMovimentacao", ">=", Timestamp.fromDate(dataInicio)),
       orderBy("dataMovimentacao", "desc")
@@ -34,7 +35,7 @@ export async function carregarDadosPrevisao(periodoMeses = 3) {
     }
   });
 
-  const snapshot = await getDocs(collection(db, "produtos"));
+  const snapshot = await getDocs(collection(db, "empresas", empresaId, "produtos"));
 
   return snapshot.docs.map(doc => {
     const data = doc.data();

--- a/js/relatorios/saidasDados.js
+++ b/js/relatorios/saidasDados.js
@@ -1,10 +1,11 @@
-import { db } from '../firebaseConfig.js';
+import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where, orderBy } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { normalizarTexto } from '../utils.js';
 
 export async function carregarDadosSaidas() {
+  const empresaId = await getEmpresaIdDoUsuario();
   const snapshot = await getDocs(
-    query(collection(db, 'movimentacoes'), where('tipo', '==', 'saida'), orderBy('dataMovimentacao', 'desc'))
+    query(collection(db, 'empresas', empresaId, 'movimentacoes'), where('tipo', '==', 'saida'), orderBy('dataMovimentacao', 'desc'))
   );
 
   return snapshot.docs.map(doc => {


### PR DESCRIPTION
## Summary
- centralize Firebase initialization and add `getEmpresaIdDoUsuario`
- fetch company id on login and auth state changes
- scope all Firestore accesses under `empresas/{empresaId}`
- adjust produtos, movimentacoes and modals for company scoping
- update reports data loaders for company structure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ea316af28832b97240d44d42fe0ab