### PR TITLE
Improve product editing UX and modal layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -220,11 +220,13 @@ tr:last-child td {
 .modal {
   display: none;
   position: fixed;
-  bottom: 20px;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   width: 95%;
   max-width: 800px;
+  max-height: 80vh;
+  overflow-y: auto;
   background: white;
   padding: 20px;
   border-radius: 10px;

--- a/financeiro.html
+++ b/financeiro.html
@@ -61,7 +61,7 @@
         </div>
       </div>
     </div>
-    <div id="fundo-modal-parcelas" class="fundo-modal"></div>
+    <div id="fundo-modal-parcelas" class="fundo-modal" onclick="fecharModalParcelas()"></div>
   </main>
 </div>
 

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -155,6 +155,7 @@ function renderizarTabela(produtos, termo = "") {
           <th>Categoria</th>
           <th>Qtd</th>
           <th>Mín.</th>
+          <th>Estoque Atual</th>
           <th>Preço</th>
           <th>Validade</th>
           <th>Fornecedor</th>
@@ -177,7 +178,7 @@ function renderizarTabela(produtos, termo = "") {
 
     const preco =
       p.precoCompra !== undefined && p.precoCompra !== null
-        ? p.precoCompra
+        ? `R$ ${(Number(p.precoCompra) || 0).toFixed(2)}`
         : "-";
 
     html += `
@@ -186,6 +187,7 @@ function renderizarTabela(produtos, termo = "") {
         <td>${p.categoria || "-"}</td>
         <td>${p.quantidade}</td>
         <td>${p.quantidadeMinima}</td>
+        <td>${p.quantidade}</td>
         <td>${preco}</td>
         <td>${dataValidade}</td>
         <td>${p.fornecedor || "-"}</td>
@@ -346,6 +348,8 @@ window.editarProduto = async function (id) {
 
     const btn = document.querySelector('#form-produto button[type="submit"]');
     btn.textContent = '💾 Salvar Alterações';
+    const cancelar = document.getElementById('cancelar-edicao');
+    if (cancelar) cancelar.style.display = 'inline-block';
 
     const form = document.getElementById('form-produto');
     form.dataset.editando = 'true';
@@ -400,6 +404,8 @@ async function salvarAlteracoesProduto() {
     form.reset();
     const btnSalvar = document.querySelector('#form-produto button[type="submit"]');
     if (btnSalvar) btnSalvar.textContent = 'Salvar Produto';
+    const cancelar = document.getElementById('cancelar-edicao');
+    if (cancelar) cancelar.style.display = 'none';
     form.dataset.editando = '';
     carregarProdutos();
     editandoProdutoId = null;
@@ -409,6 +415,19 @@ async function salvarAlteracoesProduto() {
     console.error('❌ Erro ao salvar alterações:', erro);
     mostrarErro('❌ Não foi possível salvar as alterações.', erro);
   }
+}
+
+function cancelarEdicao() {
+  const form = document.getElementById('form-produto');
+  form.reset();
+  form.dataset.editando = '';
+  const btnSalvar = document.querySelector('#form-produto button[type="submit"]');
+  if (btnSalvar) btnSalvar.textContent = 'Salvar Produto';
+  const cancelar = document.getElementById('cancelar-edicao');
+  if (cancelar) cancelar.style.display = 'none';
+  editandoProdutoId = null;
+  docRefEmEdicao = null;
+  produtoEmEdicao = null;
 }
 
 // ==========================
@@ -506,6 +525,7 @@ async function gerarESalvarCSV() {
 // ✅ Acionar salvar produto no submit do formulário
 const form = document.getElementById("form-produto");
 const btn = document.querySelector("#form-produto button[type='submit']");
+const btnCancelar = document.getElementById('cancelar-edicao');
 let listenerPadrao = null;
 
 if (form && btn) {
@@ -518,6 +538,10 @@ if (form && btn) {
     adicionarProduto();
   };
   form.addEventListener('submit', listenerPadrao);
+}
+
+if (btnCancelar) {
+  btnCancelar.addEventListener('click', cancelarEdicao);
 }
 
 // 🔧 Preencher data de entrada com a data atual ao carregar a página
@@ -547,7 +571,9 @@ window.verDetalhes = async function(id) {
     document.getElementById('det-categoria').textContent = p.categoria || '-';
     document.getElementById('det-quantidade').textContent = p.quantidade ?? '-';
     document.getElementById('det-preco').textContent =
-      p.precoCompra !== undefined && p.precoCompra !== null ? p.precoCompra : '-';
+      p.precoCompra !== undefined && p.precoCompra !== null
+        ? `R$ ${(Number(p.precoCompra) || 0).toFixed(2)}`
+        : '-';
     document.getElementById('det-fornecedor').textContent = p.fornecedor || '-';
     document.getElementById('det-validade').textContent = formatarData(p.validade);
 

--- a/produtos.html
+++ b/produtos.html
@@ -95,6 +95,7 @@
           </div>
 
           <div class="form-group full-width" style="text-align: right;">
+            <button id="cancelar-edicao" type="button" style="display:none;margin-right:10px;">❌ Cancelar Alterações</button>
             <button type="submit">Salvar Produto</button>
           </div>
         </form>
@@ -121,7 +122,7 @@
   </div>
 
   <!-- 🔧 Fundo do Modal de Confirmação -->
-  <div id="fundo-modal-confirmacao" class="fundo-modal"></div>
+  <div id="fundo-modal-confirmacao" class="fundo-modal" onclick="cancelarConfirmacao()"></div>
   
   <!-- Modal de Confirmação -->
   <div id="modal-confirmacao" class="modal">
@@ -142,7 +143,7 @@
   <script type="module" src="js/produtos.js"></script>
 
   <!-- ✅ Modal: Produto Já Existe -->
-  <div id="fundo-modal-produto-existe" class="fundo-modal"></div>
+  <div id="fundo-modal-produto-existe" class="fundo-modal" onclick="fecharModalProdutoExiste()"></div>
 
   <div id="modal-produto-existe" class="modal">
     <div class="modal-content">
@@ -154,7 +155,7 @@
   </div>
 
   <!-- 🔧 Fundo do Modal de Entrada -->
-  <div id="fundo-modal" class="fundo-modal"></div>
+  <div id="fundo-modal" class="fundo-modal" onclick="fecharModalEntrada()"></div>
 
   <!-- ✅ Modal de Entrada de Produto -->
   <div id="modal-entrada" class="modal">
@@ -200,7 +201,7 @@
   </div>
 
   <!-- 🔧 Fundo Modal Detalhes -->
-  <div id="fundo-modal-detalhes-produto" class="fundo-modal"></div>
+  <div id="fundo-modal-detalhes-produto" class="fundo-modal" onclick="fecharModalDetalhes()"></div>
 
   <!-- ✅ Modal Detalhes do Produto -->
   <div id="modal-detalhes-produto" class="modal">


### PR DESCRIPTION
## Summary
- add cancel edition button to product form
- enable closing modals by clicking their backgrounds
- center modals and limit height with scrolling
- display current stock and formatted price

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/zeliaestoque/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_685eaa840c4c832b99228981aaf263b7