### PR TITLE
Replace local CSV downloads with salvarCSV

### DIFF
--- a/js/relatorios/consumoExportar.js
+++ b/js/relatorios/consumoExportar.js
@@ -1,4 +1,4 @@
-export function exportarConsumoCSV(dados) {
+export async function exportarConsumoCSV(dados) {
   const linhas = [
     ["Produto", "Categoria", "Fornecedor", "Quantidade", "Data"],
     ...dados.map(d => [
@@ -11,16 +11,25 @@ export function exportarConsumoCSV(dados) {
   ];
 
   const csvContent = linhas
-    .map(linha => linha
-      .map(campo => `"${(campo ?? "").toString().replace(/"/g, '""')}"`)
-      .join(","))
+    .map(linha =>
+      linha
+        .map(campo => `"${(campo ?? "").toString().replace(/"/g, '""')}"`)
+        .join(",")
+    )
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-  const link = document.createElement("a");
-  link.href = URL.createObjectURL(blob);
-  link.download = `relatorio_consumo_${Date.now()}.csv`;
-  link.click();
+  try {
+    await fetch("https://us-central1-zelia-1.cloudfunctions.net/salvarCSV", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        nomeArquivo: `relatorio_consumo_${Date.now()}.csv`,
+        conteudo: csvContent
+      })
+    });
+  } catch (e) {
+    console.error("Erro ao enviar CSV:", e);
+  }
 }
 
 export async function exportarConsumoExcel(dados) {

--- a/js/relatorios/estoqueExportar.js
+++ b/js/relatorios/estoqueExportar.js
@@ -1,7 +1,7 @@
 // estoqueExportar.js — Exportação CSV e Excel do estoque
 
 // 👉 Exportar dados para CSV
-export function exportarEstoqueCSV(dados) {
+export async function exportarEstoqueCSV(dados) {
   const linhas = [
     ["Produto", "Categoria", "Fornecedor", "Quantidade", "Mínima", "Validade", "Dias p/ vencer"],
     ...dados.map(d => [
@@ -16,14 +16,25 @@ export function exportarEstoqueCSV(dados) {
   ];
 
   const csvContent = linhas
-    .map(linha => linha.map(campo => `"${(campo ?? "").toString().replace(/"/g, '""')}"`).join(","))
+    .map(linha =>
+      linha
+        .map(campo => `"${(campo ?? "").toString().replace(/"/g, '""')}"`)
+        .join(",")
+    )
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-  const link = document.createElement("a");
-  link.href = URL.createObjectURL(blob);
-  link.download = `relatorio_estoque_${Date.now()}.csv`;
-  link.click();
+  try {
+    await fetch("https://us-central1-zelia-1.cloudfunctions.net/salvarCSV", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        nomeArquivo: `relatorio_estoque_${Date.now()}.csv`,
+        conteudo: csvContent
+      })
+    });
+  } catch (e) {
+    console.error("Erro ao enviar CSV:", e);
+  }
 }
 
 // 👉 Exportar dados para Excel (.xlsx)

--- a/js/relatorios/financeiroExportar.js
+++ b/js/relatorios/financeiroExportar.js
@@ -1,7 +1,7 @@
 // financeiroExportar.js
 
 // 👉 Exportar para CSV
-export function exportarFinanceiroCSV(dados) {
+export async function exportarFinanceiroCSV(dados) {
   const linhas = [
     ["Descrição", "Categoria", "Valor", "Status", "Data Lançamento", "Vencimento", "Pagamento"],
     ...dados.map(d => [
@@ -16,14 +16,25 @@ export function exportarFinanceiroCSV(dados) {
   ];
 
   const csvContent = linhas
-    .map(l => l.map(campo => `"${(campo ?? "").toString().replace(/"/g, '""')}"`).join(","))
+    .map(l =>
+      l
+        .map(campo => `"${(campo ?? "").toString().replace(/"/g, '""')}"`)
+        .join(",")
+    )
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-  const link = document.createElement("a");
-  link.href = URL.createObjectURL(blob);
-  link.download = `relatorio_financeiro_${Date.now()}.csv`;
-  link.click();
+  try {
+    await fetch("https://us-central1-zelia-1.cloudfunctions.net/salvarCSV", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        nomeArquivo: `relatorio_financeiro_${Date.now()}.csv`,
+        conteudo: csvContent
+      })
+    });
+  } catch (e) {
+    console.error("Erro ao enviar CSV:", e);
+  }
 }
 
 // 👉 Exportar para Excel

--- a/js/relatorios/previsaoExportar.js
+++ b/js/relatorios/previsaoExportar.js
@@ -1,7 +1,7 @@
 // previsaoExportar.js — Exportação CSV e Excel da previsão
 
 // 👉 Exportar dados para CSV
-export function exportarPrevisaoCSV(dados) {
+export async function exportarPrevisaoCSV(dados) {
   const linhas = [
     ["Produto", "Categoria", "Fornecedor", "Qtd", "Consumo/Mês", "Dias Estoque", "Prev. Esgotamento", "Última Saída"],
     ...dados.map(d => [
@@ -17,14 +17,25 @@ export function exportarPrevisaoCSV(dados) {
   ];
 
   const csvContent = linhas
-    .map(linha => linha.map(campo => `"${(campo ?? "").toString().replace(/"/g, '""')}"`).join(","))
+    .map(linha =>
+      linha
+        .map(campo => `"${(campo ?? "").toString().replace(/"/g, '""')}"`)
+        .join(",")
+    )
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-  const link = document.createElement("a");
-  link.href = URL.createObjectURL(blob);
-  link.download = `relatorio_previsao_${Date.now()}.csv`;
-  link.click();
+  try {
+    await fetch("https://us-central1-zelia-1.cloudfunctions.net/salvarCSV", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        nomeArquivo: `relatorio_previsao_${Date.now()}.csv`,
+        conteudo: csvContent
+      })
+    });
+  } catch (e) {
+    console.error("Erro ao enviar CSV:", e);
+  }
 }
 
 // 👉 Exportar dados para Excel (.xlsx)


### PR DESCRIPTION
## Summary
- update consumo/estoque/financeiro/previsao export modules
  - generate CSV content and send to `salvarCSV` Cloud Function instead of creating local Blob

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eae34fa18832b9f09e459e1e9ff20