### PR TITLE
Improve Estoque filters layout and add spinner fail-safe

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -350,6 +350,33 @@ tr:last-child td {
   box-sizing: border-box;
 }
 
+/* 🔍 Filtros de páginas de relatório */
+.filtros {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+  margin-bottom: 20px;
+  padding: 10px;
+  border: 1px solid #eee;
+  border-radius: 6px;
+}
+
+.campo-filtro label {
+  font-weight: bold;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.campo-filtro input,
+.campo-filtro select {
+  width: 100%;
+  padding: 6px;
+  font-size: 14px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  box-sizing: border-box;
+}
+
 /* Responsivo */
 @media (max-width: 768px) {
   .app-container {

--- a/estoque.html
+++ b/estoque.html
@@ -31,30 +31,55 @@
       <h1>Relatórios de Estoque</h1>
 
       <!-- Filtros Avançados -->
-      <div class="filtros">
-        <input type="text" id="filtro-nome" placeholder="🔍 Produto..." list="lista-produtos">
-        <datalist id="lista-produtos"></datalist>
+      <fieldset class="filtros">
+        <div class="campo-filtro">
+          <label for="filtro-nome">Produto</label>
+          <input type="text" id="filtro-nome" placeholder="Buscar..." list="lista-produtos" title="Nome do produto para filtrar">
+          <datalist id="lista-produtos"></datalist>
+        </div>
 
-        <select id="filtro-categoria"></select>
-        <select id="filtro-fornecedor"></select>
+        <div class="campo-filtro">
+          <label for="filtro-categoria">Categoria</label>
+          <select id="filtro-categoria" title="Filtrar por categoria"></select>
+        </div>
 
-        <label for="filtro-inicio">De:</label>
-        <input type="date" id="filtro-inicio">
-        <label for="filtro-fim">Até:</label>
-        <input type="date" id="filtro-fim">
+        <div class="campo-filtro">
+          <label for="filtro-fornecedor">Fornecedor</label>
+          <select id="filtro-fornecedor" title="Filtrar por fornecedor"></select>
+        </div>
 
-        <select id="filtro-tipo">
-          <option value="todos">Todas</option>
-          <option value="entrada">Entradas</option>
-          <option value="saida">Saídas</option>
-        </select>
+        <div class="campo-filtro">
+          <label for="filtro-inicio">De</label>
+          <input type="date" id="filtro-inicio" title="Data inicial do período">
+        </div>
 
-        <label for="filtro-validade">Validade até:</label>
-        <input type="date" id="filtro-validade">
+        <div class="campo-filtro">
+          <label for="filtro-fim">Até</label>
+          <input type="date" id="filtro-fim" title="Data final do período">
+        </div>
 
-        <label><input type="checkbox" id="filtro-critico"> Estoque crítico</label>
-        <label><input type="checkbox" id="filtro-previsao"> Exibir por previsão de esgotamento</label>
-      </div>
+        <div class="campo-filtro">
+          <label for="filtro-tipo">Tipo</label>
+          <select id="filtro-tipo" title="Tipo de movimentação">
+            <option value="todos">Todas</option>
+            <option value="entrada">Entradas</option>
+            <option value="saida">Saídas</option>
+          </select>
+        </div>
+
+        <div class="campo-filtro">
+          <label for="filtro-validade">Validade até</label>
+          <input type="date" id="filtro-validade" title="Itens com validade até a data escolhida">
+        </div>
+
+        <div class="campo-filtro">
+          <label><input type="checkbox" id="filtro-critico" title="Somente itens abaixo do mínimo"> Estoque crítico</label>
+        </div>
+
+        <div class="campo-filtro">
+          <label><input type="checkbox" id="filtro-previsao" title="Ordenar por previsão de esgotamento"> Exibir por previsão de esgotamento</label>
+        </div>
+      </fieldset>
 
       <!-- Cards Totais -->
       <div id="cards-estoque-geral" class="cards">
@@ -89,5 +114,11 @@
   <script type="module" src="js/utils.js"></script>
   <script type="module" src="js/estoque/estoqueUnificado.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const spinner = document.getElementById('spinner');
+      if (spinner) spinner.style.display = 'none';
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign Estoque filters with a grid layout
- add labels and tooltips so each field is clearly identified
- hide the spinner on page load to avoid a stuck overlay
- add CSS styles for filter sections

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686293ad2014832bbb2295f908a619cc