### PR TITLE
Enable keyboard navigation across modals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -181,6 +181,11 @@ button {
   transition: background-color 0.3s;
 }
 
+button:focus {
+  outline: 2px solid #00796b;
+  outline-offset: 2px;
+}
+
 button:hover {
   background-color: #00796b;
 }

--- a/js/modais.js
+++ b/js/modais.js
@@ -35,6 +35,7 @@ export function fecharModalProdutoExiste() {
 // ✅ Modal de Confirmação
 
 let acaoConfirmada = null;
+let handlerTecladoConfirmacao = null;
 
 export function abrirModalConfirmacao(texto, acao) {
   const textoEl = document.getElementById("texto-confirmacao");
@@ -46,11 +47,42 @@ export function abrirModalConfirmacao(texto, acao) {
 
   abrirModal('modal-confirmacao');
   acaoConfirmada = acao;
+
+  const btnConfirmar = document.getElementById("btn-confirmar-acao");
+  const btnCancelar = document.getElementById("btn-cancelar-confirmacao");
+  const modal = document.getElementById("modal-confirmacao");
+
+  btnConfirmar?.focus();
+
+  handlerTecladoConfirmacao = function (e) {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      if (document.activeElement === btnConfirmar) {
+        btnCancelar?.focus();
+      } else {
+        btnConfirmar?.focus();
+      }
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (document.activeElement === btnConfirmar) {
+        confirmarAcao();
+      } else if (document.activeElement === btnCancelar) {
+        cancelarConfirmacao();
+      }
+    }
+  };
+
+  modal.addEventListener("keydown", handlerTecladoConfirmacao);
 }
 
 export function cancelarConfirmacao() {
   fecharModal('modal-confirmacao');
   acaoConfirmada = null;
+  const modal = document.getElementById('modal-confirmacao');
+  if (handlerTecladoConfirmacao) {
+    modal.removeEventListener('keydown', handlerTecladoConfirmacao);
+    handlerTecladoConfirmacao = null;
+  }
 }
 
 export function confirmarAcao() {

--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -18,6 +18,7 @@ import { registrarHistorico } from './historico.js';
 
 let produtoCadastroAtual = null;
 let dadosFinanceiroAtual = null;
+let handlerTecladoEntrada = null;
 
 // Calcula a média de preços das entradas anteriores de um produto
 async function calcularPrecoMedioEntradas(produtoId) {
@@ -96,6 +97,31 @@ export async function abrirModalEntrada(produto) {
 
   document.getElementById("modal-entrada").style.display = "block";
   document.getElementById("fundo-modal").style.display = "block";
+
+  const btnConfirmar = document.getElementById("btn-entrada-confirmar");
+  const btnCancelar = document.getElementById("btn-entrada-cancelar");
+  if (btnConfirmar) btnConfirmar.focus();
+
+  const modal = document.getElementById("modal-entrada");
+  handlerTecladoEntrada = function (e) {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      if (document.activeElement === btnConfirmar) {
+        btnCancelar?.focus();
+      } else {
+        btnConfirmar?.focus();
+      }
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (document.activeElement === btnConfirmar) {
+        window.confirmarEntradaEstoque();
+      } else if (document.activeElement === btnCancelar) {
+        fecharModalEntrada();
+      }
+    }
+  };
+
+  modal.addEventListener("keydown", handlerTecladoEntrada);
 }
 
 /**
@@ -104,6 +130,11 @@ export async function abrirModalEntrada(produto) {
 export function fecharModalEntrada() {
   document.getElementById("modal-entrada").style.display = "none";
   document.getElementById("fundo-modal").style.display = "none";
+  const modal = document.getElementById("modal-entrada");
+  if (handlerTecladoEntrada) {
+    modal.removeEventListener("keydown", handlerTecladoEntrada);
+    handlerTecladoEntrada = null;
+  }
 }
 
 async function preencherDadosFinanceiro(compraId) {

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -156,8 +156,8 @@
       <textarea id="entrada-observacoes" rows="2"></textarea>
 
       <div style="margin-top: 15px; text-align: right;">
-        <button onclick="fecharModalEntrada()">Cancelar</button>
-        <button onclick="confirmarEntradaEstoque()">Confirmar Entrada</button>
+        <button id="btn-entrada-cancelar" onclick="fecharModalEntrada()">Cancelar</button>
+        <button id="btn-entrada-confirmar" onclick="confirmarEntradaEstoque()">Confirmar Entrada</button>
       </div>
     </div>
   </div>

--- a/produtos.html
+++ b/produtos.html
@@ -198,8 +198,8 @@
       <textarea id="entrada-observacoes" rows="2"></textarea>
 
       <div style="margin-top: 15px; text-align: right;">
-        <button onclick="fecharModalEntrada()">Cancelar</button>
-        <button onclick="confirmarEntradaEstoque()">Confirmar Entrada</button>
+        <button id="btn-entrada-cancelar" onclick="fecharModalEntrada()">Cancelar</button>
+        <button id="btn-entrada-confirmar" onclick="confirmarEntradaEstoque()">Confirmar Entrada</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- allow buttons to receive focus styling
- implement keyboard navigation for confirmation modal
- enable same behaviour for modal de entrada
- add IDs to entry modal buttons for focus

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6862aa42aac4832b9a1ad4863e01241e