### PR TITLE
Add smart modal for duplicate product

### DIFF
--- a/js/modais.js
+++ b/js/modais.js
@@ -23,12 +23,33 @@ export function fecharModal(idModal) {
 
 // ✅ Modal: Produto Já Existe
 
-export function abrirModalProdutoExiste() {
+let produtoDuplicadoTemp = "";
+
+export function abrirModalProdutoExiste(nomeProduto) {
+  produtoDuplicadoTemp = nomeProduto || "";
   abrirModal('modal-produto-existe');
+  const btnIr = document.getElementById('btn-ir-movimentacoes');
+  btnIr?.focus();
 }
 
 export function fecharModalProdutoExiste() {
   fecharModal('modal-produto-existe');
+}
+
+export function irParaMovimentacoesComNome() {
+  if (produtoDuplicadoTemp) {
+    sessionStorage.setItem('nomeProdutoMovimentacao', produtoDuplicadoTemp);
+  }
+  window.location.href = 'movimentacoes.html';
+}
+
+export function cadastrarOutroProduto() {
+  fecharModalProdutoExiste();
+  const campoNome = document.getElementById('nome');
+  if (campoNome) {
+    campoNome.value = '';
+    campoNome.focus();
+  }
 }
 
 
@@ -122,5 +143,7 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 window.fecharModalProdutoExiste = fecharModalProdutoExiste;
+window.irParaMovimentacoesComNome = irParaMovimentacoesComNome;
+window.cadastrarOutroProduto = cadastrarOutroProduto;
 window.cancelarConfirmacao = cancelarConfirmacao;
 window.confirmarAcao = confirmarAcao;

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -63,6 +63,18 @@ document.addEventListener("DOMContentLoaded", () => {
   if (campoData && !campoData.value) {
     campoData.value = hoje;
   }
+
+  const nomeArmazenado = sessionStorage.getItem('nomeProdutoMovimentacao');
+  if (nomeArmazenado) {
+    const inputNome = document.getElementById('nome-produto');
+    if (inputNome) {
+      inputNome.value = nomeArmazenado;
+      sessionStorage.removeItem('nomeProdutoMovimentacao');
+      setTimeout(() => {
+        document.getElementById('tipo-movimentacao')?.focus();
+      }, 10);
+    }
+  }
 });
 
 // =========================

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -312,8 +312,7 @@ async function adicionarProduto() {
       const snapshot = await getDocs(q);
 
       if (!snapshot.empty) {
-        // console.warn("⚠️ Produto já existe!");
-        abrirModalProdutoExiste();
+        abrirModalProdutoExiste(nome);
         return;
       }
 
@@ -550,7 +549,7 @@ document.getElementById("nome").addEventListener("blur", function () {
     if (!snapshot.empty) {
       const existeOutro = snapshot.docs.some(doc => doc.id !== editandoProdutoId);
       if (existeOutro) {
-        abrirModalProdutoExiste();
+        abrirModalProdutoExiste(input.value.trim());
         input.value = "";
         const sugestoes = document.getElementById("sugestoes-nome");
         if (sugestoes) sugestoes.style.display = "none";

--- a/produtos.html
+++ b/produtos.html
@@ -151,10 +151,12 @@
 
   <div id="modal-produto-existe" class="modal">
     <div class="modal-content">
-      <p>⚠️ Ops! Esse produto já está cadastrado em nosso estoque.<br>
-      Para registrar uma nova entrada, vá até a aba <strong>Movimentações</strong>.</p>
-
-      <button onclick="fecharModalProdutoExiste()">OK</button>
+      <p>⚠️ Opa! Esse produto já está cadastrado no seu estoque!<br>
+      Deseja lançar uma movimentação para esse produto ou cadastrar um novo no sistema?</p>
+      <div style="text-align:right; margin-top: 20px;">
+        <button id="btn-ir-movimentacoes" onclick="irParaMovimentacoesComNome()">Ir para movimentações</button>
+        <button id="btn-cadastrar-outro" onclick="cadastrarOutroProduto()">Cadastrar outro produto</button>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- improve duplicate product modal with actions
- redirect to Movimentações with stored product name
- prefill movimentação form when redirected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68654b297788832ba648483559fd2c13