### PR TITLE
Revamp financeiro layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10,7 +10,8 @@
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Open Sans', sans-serif;
   background-color: #f9f9f9;
-  color: #444;
+  color: #374151; /* text-gray-700 */
+  font-size: 16px; /* text-base */
 }
 
 a {
@@ -200,6 +201,21 @@ table {
   box-shadow: 0 2px 6px rgba(0,0,0,0.05);
 }
 
+#tabela-financeiro th:nth-child(1),
+#tabela-financeiro td:nth-child(1) {
+  width: 100px;
+}
+
+#tabela-financeiro th:nth-child(3),
+#tabela-financeiro td:nth-child(3) {
+  width: 140px;
+}
+
+#tabela-financeiro th:nth-child(5),
+#tabela-financeiro td:nth-child(5) {
+  text-align: right;
+}
+
 th, td {
   padding: 12px;
   border-bottom: 1px solid #eee;
@@ -219,18 +235,26 @@ tr:last-child td {
   border-bottom: none;
 }
 
+table tbody tr:hover {
+  background-color: #f9fafb; /* hover:bg-gray-50 */
+}
+
 /* Cards */
 .cards {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   margin: 10px 0;
 }
 
 .card {
-  background: #fafafa;
-  padding: 10px;
-  border: 1px solid #ddd;
-  border-radius: 6px;
+  background: #ffffff;
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  flex: 1;
+  text-align: center;
 }
 
 /* Alerts */
@@ -370,6 +394,8 @@ tr:last-child td {
   font-weight: bold;
   display: block;
   margin-bottom: 4px;
+  color: #6b7280; /* text-gray-500 */
+  font-size: 14px; /* text-sm */
 }
 
 .campo-filtro input,
@@ -380,6 +406,13 @@ tr:last-child td {
   border-radius: 4px;
   border: 1px solid #ccc;
   box-sizing: border-box;
+}
+
+/* Grupo de botões nos filtros */
+.botoes {
+  display: flex;
+  gap: 8px;
+  align-items: end;
 }
 
 /* Responsivo */
@@ -467,6 +500,22 @@ tr.critico-suave {
 
 .btn-repor:hover {
   background-color: #d68910;
+}
+
+/* Botões de ações do financeiro */
+.btn-acao {
+  background-color: #009688;
+  color: #fff;
+  padding: 8px 16px; /* px-4 py-2 */
+  border-radius: 12px; /* rounded-xl */
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  font-size: 14px;
+}
+
+.btn-acao:hover {
+  background-color: #00796b;
 }
 
 /* Cabeçalho fixo para a tabela de entradas */

--- a/financeiro.html
+++ b/financeiro.html
@@ -29,21 +29,39 @@
     <h1>💰 Financeiro</h1>
 
     <div class="filtros">
-      <label>De:</label>
-      <input type="date" id="fin-data-inicio">
-      <label>Até:</label>
-      <input type="date" id="fin-data-fim">
+      <div class="campo-filtro">
+        <label for="fin-data-inicio">De</label>
+        <input type="date" id="fin-data-inicio">
+      </div>
+      <div class="campo-filtro">
+        <label for="fin-data-fim">Até</label>
+        <input type="date" id="fin-data-fim">
+      </div>
 
-      <input type="text" id="fin-compra-id" placeholder="CompraID" list="lista-compra-fin" style="width:140px;">
-      <datalist id="lista-compra-fin"></datalist>
-      <select id="fin-fornecedor"></select>
-      <select id="fin-forma"></select>
-      <select id="fin-status"></select>
+      <div class="campo-filtro">
+        <label for="fin-compra-id">CompraID</label>
+        <input type="text" id="fin-compra-id" placeholder="Buscar..." list="lista-compra-fin">
+        <datalist id="lista-compra-fin"></datalist>
+      </div>
+      <div class="campo-filtro">
+        <label for="fin-fornecedor">Fornecedor</label>
+        <select id="fin-fornecedor"></select>
+      </div>
+      <div class="campo-filtro">
+        <label for="fin-forma">Forma</label>
+        <select id="fin-forma"></select>
+      </div>
+      <div class="campo-filtro">
+        <label for="fin-status">Status</label>
+        <select id="fin-status"></select>
+      </div>
 
-      <button id="botao-atualizar-fin">🔄 Atualizar</button>
-      <button id="botao-limpar-fin">🧹 Limpar</button>
-      <button id="botao-exportar-csv-fin">📄 CSV</button>
-      <button id="botao-exportar-excel-fin">📊 Excel</button>
+      <div class="campo-filtro botoes">
+        <button id="botao-atualizar-fin" class="btn-acao">🔄 Atualizar</button>
+        <button id="botao-limpar-fin" class="btn-acao">🧹 Limpar</button>
+        <button id="botao-exportar-csv-fin" class="btn-acao">📥 CSV</button>
+        <button id="botao-exportar-excel-fin" class="btn-acao">🖨️ Excel</button>
+      </div>
     </div>
 
     <div id="cards-financeiro" class="cards">


### PR DESCRIPTION
## Summary
- restyle Financeiro filters using grid
- add consistent rounded buttons with icons
- adjust table spacing and column widths
- refine summary cards
- soften text colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68657276f16c832b9e14fa98e7fbbded