### PR TITLE
Add finance summary cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -19,6 +19,11 @@ a {
   text-decoration: none;
 }
 
+.text-sm { font-size: 14px; }
+.text-xl { font-size: 20px; }
+.text-gray-500 { color: #6b7280; }
+.font-semibold { font-weight: 600; }
+
 /* P\u00E1ginas de autentica\u00E7\u00E3o (login e cadastro) */
 .auth-page {
   min-height: 100vh;
@@ -256,6 +261,25 @@ table tbody tr:hover {
   flex: 1;
   text-align: center;
 }
+
+.resumo-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #ffffff;
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  flex: 1 1 200px;
+}
+
+.resumo-card.pago { background-color: #eafaf1; }
+.resumo-card.pendente { background-color: #fff8e6; }
+.resumo-card.vencido { background-color: #fdecea; }
+
+.resumo-card .titulo { font-size: 14px; color: #6b7280; }
+.resumo-card .valor { font-size: 20px; font-weight: 600; }
 
 /* Alerts */
 .alert-erro {

--- a/financeiro.html
+++ b/financeiro.html
@@ -65,9 +65,34 @@
     </div>
 
     <div id="cards-financeiro" class="cards">
-      <div class="card"><strong>A pagar:</strong> <span id="total-pagar">-</span></div>
-      <div class="card"><strong>Pagos:</strong> <span id="total-pagos">-</span></div>
-      <div class="card"><strong>Recebidos:</strong> <span id="total-recebidos">-</span></div>
+      <div class="resumo-card" id="card-total-comprado">
+        <div class="icone">💸</div>
+        <div class="texto">
+          <div class="titulo text-sm text-gray-500">Total comprado</div>
+          <div class="valor text-xl font-semibold" id="total-comprado">-</div>
+        </div>
+      </div>
+      <div class="resumo-card pago" id="card-total-pago">
+        <div class="icone">📅</div>
+        <div class="texto">
+          <div class="titulo text-sm text-gray-500">Total pago</div>
+          <div class="valor text-xl font-semibold" id="total-pago">-</div>
+        </div>
+      </div>
+      <div class="resumo-card pendente" id="card-total-pendente">
+        <div class="icone">⏳</div>
+        <div class="texto">
+          <div class="titulo text-sm text-gray-500">Total pendente</div>
+          <div class="valor text-xl font-semibold" id="total-pendente">-</div>
+        </div>
+      </div>
+      <div class="resumo-card vencido" id="card-total-vencido">
+        <div class="icone">🔴</div>
+        <div class="texto">
+          <div class="titulo text-sm text-gray-500">Total vencido</div>
+          <div class="valor text-xl font-semibold" id="total-vencido">-</div>
+        </div>
+      </div>
     </div>
 
     <div id="tabela-financeiro"></div>

--- a/js/relatorios/financeiroTotais.js
+++ b/js/relatorios/financeiroTotais.js
@@ -1,27 +1,43 @@
 // financeiroTotais.js — Cálculo e atualização dos cards
 
 export function calcularTotaisFinanceiro(dados) {
-  let totalPagar = 0;
-  let pagos = 0;
-  let recebidos = 0;
+  let totalComprado = 0;
+  let totalPago = 0;
+  let totalPendente = 0;
+  let totalVencido = 0;
+
+  const hoje = new Date();
 
   dados.forEach(d => {
-    if (d.tipo === "pagar") {
-      totalPagar += d.valor;
-      if (d.status === "pago") pagos += d.valor;
-    }
-    if (d.tipo === "receber") {
-      if (d.status === "recebido") recebidos += d.valor;
-    }
+    const parcelas = Array.isArray(d.parcelas) && d.parcelas.length > 0
+      ? d.parcelas
+      : [{ valor: d.valor, vencimento: d.dataVencimento, status: d.status }];
+
+    parcelas.forEach(p => {
+      const valor = Number(p.valor) || 0;
+      totalComprado += valor;
+
+      if (p.status === 'pago') {
+        totalPago += valor;
+      } else {
+        const venc = p.vencimento ? new Date(p.vencimento) : null;
+        if (venc && venc < hoje) {
+          totalVencido += valor;
+        } else {
+          totalPendente += valor;
+        }
+      }
+    });
   });
 
-  return { totalPagar, pagos, recebidos };
+  return { totalComprado, totalPago, totalPendente, totalVencido };
 }
 
 export function atualizarCardsFinanceiro(dados) {
   const totais = calcularTotaisFinanceiro(dados);
 
-  document.getElementById("total-pagar").textContent = `R$ ${totais.totalPagar.toFixed(2)}`;
-  document.getElementById("total-pagos").textContent = `R$ ${totais.pagos.toFixed(2)}`;
-  document.getElementById("total-recebidos").textContent = `R$ ${totais.recebidos.toFixed(2)}`;
+  document.getElementById('total-comprado').textContent = `R$ ${totais.totalComprado.toFixed(2)}`;
+  document.getElementById('total-pago').textContent = `R$ ${totais.totalPago.toFixed(2)}`;
+  document.getElementById('total-pendente').textContent = `R$ ${totais.totalPendente.toFixed(2)}`;
+  document.getElementById('total-vencido').textContent = `R$ ${totais.totalVencido.toFixed(2)}`;
 }


### PR DESCRIPTION
## Summary
- enhance Financeiro page with summary cards
- style new cards and helper typography utilities
- compute totals of paid, pending and overdue installments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865744cdf08832baefddd1606ac4694