### PR TITLE
Add advanced filters to Financeiro dashboard

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -52,6 +52,10 @@
         <select id="fin-forma"></select>
       </div>
       <div class="campo-filtro">
+        <label for="fin-categoria-prod">Categoria prod.</label>
+        <select id="fin-categoria-prod"></select>
+      </div>
+      <div class="campo-filtro">
         <label for="fin-status">Status</label>
         <select id="fin-status"></select>
       </div>

--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -35,6 +35,7 @@ export function limparFiltrosFinanceiro() {
   document.getElementById('fin-fornecedor').value = '';
   document.getElementById('fin-forma').value = '';
   document.getElementById('fin-status').value = '';
+  document.getElementById('fin-categoria-prod').value = '';
 
   gerarTabelaFinanceiro();
 }

--- a/js/relatorios/financeiroDados.js
+++ b/js/relatorios/financeiroDados.js
@@ -1,7 +1,7 @@
 // financeiroDados.js — Buscar dados do Firestore
 
 import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
-import { collection, getDocs, query, orderBy } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
+import { collection, getDocs, query, orderBy, where } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
 export async function carregarDadosFinanceiro(periodoMeses = 3) {
   const hoje = new Date();
@@ -13,6 +13,17 @@ export async function carregarDadosFinanceiro(periodoMeses = 3) {
     query(collection(db, "empresas", empresaId, "financeiro"), orderBy("dataLancamento", "desc"))
   );
 
+  const categoriasPorCompra = {};
+  const movSnap = await getDocs(
+    query(collection(db, 'empresas', empresaId, 'movimentacoes'), where('tipo', '==', 'entrada'))
+  );
+  movSnap.forEach(m => {
+    const d = m.data();
+    if (!d.compraId) return;
+    if (!categoriasPorCompra[d.compraId]) categoriasPorCompra[d.compraId] = new Set();
+    if (d.categoria) categoriasPorCompra[d.compraId].add(d.categoria);
+  });
+
   return snapshot.docs
     .map(doc => {
       const d = doc.data();
@@ -23,7 +34,7 @@ export async function carregarDadosFinanceiro(periodoMeses = 3) {
       const parcelas = Array.isArray(d.parcelas) ? d.parcelas : [];
 
       const hoje = new Date();
-      let statusParcelas = "paga";
+      let statusParcelas = "pago";
       let temVencida = false;
       parcelas.forEach(p => {
         const venc = p.vencimento ? new Date(p.vencimento) : null;
@@ -32,7 +43,11 @@ export async function carregarDadosFinanceiro(periodoMeses = 3) {
           if (venc && venc < hoje) temVencida = true;
         }
       });
-      if (temVencida) statusParcelas = "vencida";
+      if (temVencida) statusParcelas = "vencido";
+
+      const categorias = categoriasPorCompra[d.compraId]
+        ? Array.from(categoriasPorCompra[d.compraId])
+        : [];
 
       return {
         id: doc.id,
@@ -44,6 +59,7 @@ export async function carregarDadosFinanceiro(periodoMeses = 3) {
         compraId: d.compraId || "-",
         parcelas,
         statusParcelas,
+        categoriasProdutos: categorias,
         fornecedorOuCliente: d.fornecedorOuCliente || "-",
         formaPagamento: d.formaPagamento || "-",
         dataLancamento: dataLanc,

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -17,16 +17,19 @@ export function gerarFiltrosFinanceiro() {
   const formas = new Set();
   const compras = new Set();
   const statusParcelas = new Set();
+  const categoriasProd = new Set();
 
   const selFornecedor = document.getElementById('fin-fornecedor').value;
   const selForma = document.getElementById('fin-forma').value;
   const selStatus = document.getElementById('fin-status').value;
+  const selCatProd = document.getElementById('fin-categoria-prod').value;
 
   dados.forEach(d => {
     if (d.fornecedorOuCliente) fornecedores.add(d.fornecedorOuCliente);
     if (d.formaPagamento) formas.add(d.formaPagamento);
     if (d.compraId) compras.add(d.compraId);
     if (d.statusParcelas) statusParcelas.add(d.statusParcelas);
+    if (Array.isArray(d.categoriasProdutos)) d.categoriasProdutos.forEach(c => categoriasProd.add(c));
   });
 
   document.getElementById('fin-fornecedor').innerHTML =
@@ -41,15 +44,20 @@ export function gerarFiltrosFinanceiro() {
     `<option value="">Status</option>` +
     [...statusParcelas].sort().map(s => `<option value="${s}">${s}</option>`).join('');
 
+  document.getElementById('fin-categoria-prod').innerHTML =
+    `<option value="">Categoria prod.</option>` +
+    [...categoriasProd].sort().map(c => `<option value="${c}">${c}</option>`).join('');
+
   document.getElementById('lista-compra-fin').innerHTML =
     [...compras].sort().map(c => `<option value="${c}">`).join('');
 
   document.getElementById('fin-fornecedor').value = selFornecedor;
   document.getElementById('fin-forma').value = selForma;
   document.getElementById('fin-status').value = selStatus;
+  document.getElementById('fin-categoria-prod').value = selCatProd;
 
   if (!filtrosIniciados) {
-    ['fin-fornecedor','fin-forma','fin-status','fin-compra-id','fin-data-inicio','fin-data-fim']
+    ['fin-fornecedor','fin-forma','fin-status','fin-categoria-prod','fin-compra-id','fin-data-inicio','fin-data-fim']
       .forEach(id => {
         document.getElementById(id)?.addEventListener('input', gerarTabelaFinanceiro);
       });
@@ -65,6 +73,7 @@ export function gerarTabelaFinanceiro() {
   const formaFiltro = document.getElementById('fin-forma').value;
   const compraFiltro = document.getElementById('fin-compra-id').value.trim();
   const statusFiltro = document.getElementById('fin-status').value;
+  const catProdFiltro = document.getElementById('fin-categoria-prod').value;
   const inicio = document.getElementById('fin-data-inicio').value;
   const fim = document.getElementById('fin-data-fim').value;
   const inicioData = inicio ? parseDataLocal(inicio) : null;
@@ -75,6 +84,7 @@ export function gerarTabelaFinanceiro() {
     const formaMatch = formaFiltro === '' || d.formaPagamento === formaFiltro;
     const compraMatch = compraFiltro === '' || d.compraId === compraFiltro;
     const statusMatch = statusFiltro === '' || d.statusParcelas === statusFiltro;
+    const catProdMatch = catProdFiltro === '' || (Array.isArray(d.categoriasProdutos) && d.categoriasProdutos.includes(catProdFiltro));
 
     let vencMatch = true;
     if (inicioData || fimData) {
@@ -93,7 +103,7 @@ export function gerarTabelaFinanceiro() {
       });
     }
 
-    return fornMatch && formaMatch && compraMatch && statusMatch && vencMatch;
+    return fornMatch && formaMatch && compraMatch && statusMatch && catProdMatch && vencMatch;
   });
 
   if (filtrados.length === 0) {


### PR DESCRIPTION
## Summary
- add product category filter on Financeiro page
- include new reset logic for the extra filter
- collect product categories from movement entries when loading financeiro data
- compute parcel status per installment and expose categories
- allow filtering by the new fields when rendering the table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68657e3e6920832b975beb1a0eb60fe2