### PR TITLE
Add XLSX and PDF export to Financeiro

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -64,7 +64,8 @@
         <button id="botao-atualizar-fin" class="btn-acao">🔄 Atualizar</button>
         <button id="botao-limpar-fin" class="btn-acao">🧹 Limpar</button>
         <button id="botao-exportar-csv-fin" class="btn-acao">📥 CSV</button>
-        <button id="botao-exportar-excel-fin" class="btn-acao">🖨️ Excel</button>
+        <button id="botao-exportar-excel-fin" class="btn-acao">📥 Exportar .xlsx</button>
+        <button id="botao-exportar-pdf-fin" class="btn-acao">🖨️ Exportar PDF</button>
       </div>
     </div>
 

--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -1,8 +1,8 @@
 // financeiro.js — Controlador geral do módulo financeiro
 
 import { carregarDadosFinanceiro } from './financeiroDados.js';
-import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro } from './financeiroTabela.js';
-import { exportarFinanceiroCSV, exportarFinanceiroExcel } from './financeiroExportar.js';
+import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro, dadosFiltradosFinanceiro } from './financeiroTabela.js';
+import { exportarFinanceiroCSV, exportarFinanceiroExcel, exportarFinanceiroPDF } from './financeiroExportar.js';
 import { mostrarSpinner, esconderSpinner, mostrarMensagem } from '../utils.js';
 import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where, doc, updateDoc } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
@@ -50,7 +50,11 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   document.getElementById("botao-exportar-excel-fin")?.addEventListener("click", () => {
-    exportarFinanceiroExcel(dadosFinanceiro);
+    exportarFinanceiroExcel(dadosFiltradosFinanceiro());
+  });
+
+  document.getElementById("botao-exportar-pdf-fin")?.addEventListener("click", () => {
+    exportarFinanceiroPDF(dadosFiltradosFinanceiro());
   });
 
   atualizarTabelaFinanceiro();

--- a/js/relatorios/financeiroExportar.js
+++ b/js/relatorios/financeiroExportar.js
@@ -1,6 +1,13 @@
 // financeiroExportar.js
 
-// 👉 Exportar para CSV
+function nomeRelatorio(ext) {
+  const d = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  const data = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}-${pad(d.getHours())}-${pad(d.getMinutes())}`;
+  return `relatorio_financeiro_${data}.${ext}`;
+}
+
+// 👉 Exportar para CSV (mantido para compatibilidade)
 export async function exportarFinanceiroCSV(dados) {
   const linhas = [
     ["Descrição", "Categoria", "Valor", "Status", "Data Lançamento", "Vencimento", "Pagamento"],
@@ -16,44 +23,104 @@ export async function exportarFinanceiroCSV(dados) {
   ];
 
   const csvContent = linhas
-    .map(l =>
-      l
-        .map(campo => `"${(campo ?? "").toString().replace(/"/g, '""')}"`)
-        .join(",")
-    )
+    .map(l => l.map(c => `"${(c ?? "").toString().replace(/"/g, '""')}"`).join(","))
     .join("\n");
 
   try {
     await fetch("https://us-central1-zelia-1.cloudfunctions.net/salvarCSV", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        nomeArquivo: `relatorio_financeiro_${Date.now()}.csv`,
-        conteudo: csvContent
-      })
+      body: JSON.stringify({ nomeArquivo: nomeRelatorio('csv'), conteudo: csvContent })
     });
   } catch (e) {
     console.error("Erro ao enviar CSV:", e);
   }
 }
 
-// 👉 Exportar para Excel
+// 👉 Exportar para Excel com compras e parcelas filtradas
 export async function exportarFinanceiroExcel(dados) {
-  const { utils, writeFile } = await import("https://cdn.sheetjs.com/xlsx-latest/package/xlsx.mjs");
+  const { utils, writeFile } = await import('https://cdn.sheetjs.com/xlsx-latest/package/xlsx.mjs');
 
-  const linhas = dados.map(d => ({
-    Descricao: d.descricao,
-    Categoria: d.categoria,
-    Valor: d.valor,
-    Status: d.status,
-    DataLancamento: d.dataLancamento ? d.dataLancamento.toLocaleDateString('pt-BR') : "-",
-    Vencimento: d.dataVencimento ? d.dataVencimento.toLocaleDateString('pt-BR') : "-",
-    Pagamento: d.dataPagamento ? d.dataPagamento.toLocaleDateString('pt-BR') : "-"
-  }));
+  const linhas = [];
+  dados.forEach(d => {
+    const parcelas = Array.isArray(d.parcelas) && d.parcelas.length > 0
+      ? d.parcelas
+      : [{ numero: 1, valor: d.valor, vencimento: d.dataVencimento, status: d.status, dataPagamento: d.dataPagamento }];
+
+    parcelas.forEach(p => {
+      linhas.push({
+        CompraID: d.compraId,
+        Fornecedor: d.fornecedorOuCliente,
+        DataCompra: d.dataLancamento ? d.dataLancamento.toLocaleDateString('pt-BR') : '-',
+        FormaPagamento: d.formaPagamento,
+        ValorTotal: d.valor,
+        Parcela: p.numero,
+        ValorParcela: p.valor,
+        Vencimento: p.vencimento ? new Date(p.vencimento).toLocaleDateString('pt-BR') : '-',
+        StatusParcela: p.status,
+        Pagamento: p.dataPagamento ? new Date(p.dataPagamento).toLocaleDateString('pt-BR') : '-'
+      });
+    });
+  });
 
   const worksheet = utils.json_to_sheet(linhas);
   const workbook = utils.book_new();
-  utils.book_append_sheet(workbook, worksheet, "Financeiro");
+  utils.book_append_sheet(workbook, worksheet, 'Financeiro');
 
-  writeFile(workbook, `relatorio_financeiro_${Date.now()}.xlsx`);
+  writeFile(workbook, nomeRelatorio('xlsx'));
+}
+
+// 👉 Exportar relatório em PDF
+export async function exportarFinanceiroPDF(dados) {
+  const { jsPDF } = await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.es.min.js');
+  const { calcularTotaisFinanceiro } = await import('./financeiroTotais.js');
+
+  const doc = new jsPDF();
+  doc.text('Relatório Financeiro', 14, 16);
+
+  const inicio = document.getElementById('fin-data-inicio').value;
+  const fim = document.getElementById('fin-data-fim').value;
+  if (inicio || fim) {
+    doc.text(`Período: ${inicio || '-'} a ${fim || '-'}`, 14, 22);
+  }
+
+  const totais = calcularTotaisFinanceiro(dados);
+  doc.text(`Total comprado: R$ ${totais.totalComprado.toFixed(2)}`, 14, 30);
+  doc.text(`Total pago: R$ ${totais.totalPago.toFixed(2)}`, 14, 36);
+  doc.text(`Total pendente: R$ ${totais.totalPendente.toFixed(2)}`, 14, 42);
+  doc.text(`Total vencido: R$ ${totais.totalVencido.toFixed(2)}`, 14, 48);
+
+  const linhas = [];
+  dados.forEach(d => {
+    const base = [
+      d.compraId,
+      d.fornecedorOuCliente,
+      d.dataLancamento ? d.dataLancamento.toLocaleDateString('pt-BR') : '-',
+      d.formaPagamento,
+      (d.valor || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+    ];
+    const parcelas = Array.isArray(d.parcelas) && d.parcelas.length > 0
+      ? d.parcelas
+      : [{ numero: 1, valor: d.valor, vencimento: d.dataVencimento, status: d.status, dataPagamento: d.dataPagamento }];
+    parcelas.forEach(p => {
+      linhas.push([
+        ...base,
+        p.numero,
+        (p.valor || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }),
+        p.vencimento ? new Date(p.vencimento).toLocaleDateString('pt-BR') : '-',
+        p.status,
+        p.dataPagamento ? new Date(p.dataPagamento).toLocaleDateString('pt-BR') : '-'
+      ]);
+    });
+  });
+
+  doc.autoTable({
+    head: [[
+      'CompraID','Fornecedor','Data','Forma','Valor compra','Parcela','Valor','Vencimento','Status','Pagamento'
+    ]],
+    body: linhas,
+    startY: 54
+  });
+
+  doc.save(nomeRelatorio('pdf'));
 }

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -11,6 +11,46 @@ export function setDadosFinanceiro(novosDados) {
   dados = novosDados;
 }
 
+// 🔍 Obter dados conforme filtros aplicados
+export function dadosFiltradosFinanceiro() {
+  const fornecedorFiltro = document.getElementById('fin-fornecedor').value;
+  const formaFiltro = document.getElementById('fin-forma').value;
+  const compraFiltro = document.getElementById('fin-compra-id').value.trim();
+  const statusFiltro = document.getElementById('fin-status').value;
+  const catProdFiltro = document.getElementById('fin-categoria-prod').value;
+  const inicio = document.getElementById('fin-data-inicio').value;
+  const fim = document.getElementById('fin-data-fim').value;
+  const inicioData = inicio ? parseDataLocal(inicio) : null;
+  const fimData = fim ? parseDataLocal(fim) : null;
+
+  return dados.filter(d => {
+    const fornMatch = fornecedorFiltro === '' || d.fornecedorOuCliente === fornecedorFiltro;
+    const formaMatch = formaFiltro === '' || d.formaPagamento === formaFiltro;
+    const compraMatch = compraFiltro === '' || d.compraId === compraFiltro;
+    const statusMatch = statusFiltro === '' || d.statusParcelas === statusFiltro;
+    const catProdMatch = catProdFiltro === '' || (Array.isArray(d.categoriasProdutos) && d.categoriasProdutos.includes(catProdFiltro));
+
+    let vencMatch = true;
+    if (inicioData || fimData) {
+      const vencs = [];
+      if (Array.isArray(d.parcelas)) {
+        d.parcelas.forEach(p => {
+          if (p.vencimento) vencs.push(parseDataLocal(p.vencimento));
+        });
+      }
+      if (vencs.length === 0 && d.dataVencimento) vencs.push(parseDataLocal(d.dataVencimento));
+      vencMatch = vencs.some(v => {
+        if (!v || isNaN(v)) return false;
+        if (inicioData && v < inicioData) return false;
+        if (fimData && v > fimData) return false;
+        return true;
+      });
+    }
+
+    return fornMatch && formaMatch && compraMatch && statusMatch && catProdMatch && vencMatch;
+  });
+}
+
 // 🔍 Gerar filtros dinâmicos
 export function gerarFiltrosFinanceiro() {
   const fornecedores = new Set();
@@ -69,42 +109,7 @@ export function gerarFiltrosFinanceiro() {
 export function gerarTabelaFinanceiro() {
   const lista = document.getElementById("tabela-financeiro");
 
-  const fornecedorFiltro = document.getElementById('fin-fornecedor').value;
-  const formaFiltro = document.getElementById('fin-forma').value;
-  const compraFiltro = document.getElementById('fin-compra-id').value.trim();
-  const statusFiltro = document.getElementById('fin-status').value;
-  const catProdFiltro = document.getElementById('fin-categoria-prod').value;
-  const inicio = document.getElementById('fin-data-inicio').value;
-  const fim = document.getElementById('fin-data-fim').value;
-  const inicioData = inicio ? parseDataLocal(inicio) : null;
-  const fimData = fim ? parseDataLocal(fim) : null;
-
-  const filtrados = dados.filter(d => {
-    const fornMatch = fornecedorFiltro === '' || d.fornecedorOuCliente === fornecedorFiltro;
-    const formaMatch = formaFiltro === '' || d.formaPagamento === formaFiltro;
-    const compraMatch = compraFiltro === '' || d.compraId === compraFiltro;
-    const statusMatch = statusFiltro === '' || d.statusParcelas === statusFiltro;
-    const catProdMatch = catProdFiltro === '' || (Array.isArray(d.categoriasProdutos) && d.categoriasProdutos.includes(catProdFiltro));
-
-    let vencMatch = true;
-    if (inicioData || fimData) {
-      const vencs = [];
-      if (Array.isArray(d.parcelas)) {
-        d.parcelas.forEach(p => {
-          if (p.vencimento) vencs.push(parseDataLocal(p.vencimento));
-        });
-      }
-      if (vencs.length === 0 && d.dataVencimento) vencs.push(parseDataLocal(d.dataVencimento));
-      vencMatch = vencs.some(v => {
-        if (!v || isNaN(v)) return false;
-        if (inicioData && v < inicioData) return false;
-        if (fimData && v > fimData) return false;
-        return true;
-      });
-    }
-
-    return fornMatch && formaMatch && compraMatch && statusMatch && catProdMatch && vencMatch;
-  });
+  const filtrados = dadosFiltradosFinanceiro();
 
   if (filtrados.length === 0) {
     lista.innerHTML = "<p>❌ Nenhum dado encontrado.</p>";


### PR DESCRIPTION
## Summary
- update Financeiro page export buttons
- add filtered data helpers and PDF/Excel exports
- generate Excel and PDF reports with filename including date/time

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6865830cd4cc832bb460396a45f1f617