### PR TITLE
Add financial category summary

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -103,6 +103,9 @@
 
     <div id="tabela-financeiro"></div>
 
+    <h2 style="margin-top:20px;">Gastos por Categoria de Produto</h2>
+    <div id="tabela-fin-categorias"></div>
+
     <div id="modal-parcelas" class="modal">
       <div class="modal-content">
         <h3>Parcelas - Compra <span id="modal-compra-id"></span></h3>

--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -2,12 +2,14 @@
 
 import { carregarDadosFinanceiro } from './financeiroDados.js';
 import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro, dadosFiltradosFinanceiro } from './financeiroTabela.js';
+import { carregarEntradasFinanceiro } from './financeiroCategorias.js';
 import { exportarFinanceiroCSV, exportarFinanceiroExcel, exportarFinanceiroPDF } from './financeiroExportar.js';
 import { mostrarSpinner, esconderSpinner, mostrarMensagem } from '../utils.js';
 import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where, doc, updateDoc } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
 let dadosFinanceiro = [];
+let entradasFinanceiro = [];
 
 function exibirAlertaVencidas() {
   const aviso = document.getElementById('alerta-vencidas');
@@ -48,6 +50,7 @@ export async function atualizarTabelaFinanceiro() {
     mostrarSpinner();
 
     dadosFinanceiro = await carregarDadosFinanceiro();
+    entradasFinanceiro = await carregarEntradasFinanceiro();
 
     setDadosFinanceiro(dadosFinanceiro);
     gerarFiltrosFinanceiro();

--- a/js/relatorios/financeiroCategorias.js
+++ b/js/relatorios/financeiroCategorias.js
@@ -1,0 +1,84 @@
+// financeiroCategorias.js — Gasto por categoria de produto
+
+import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
+import { collection, getDocs, query, where } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { parseDataLocal } from '../utils.js';
+
+let entradas = [];
+
+export async function carregarEntradasFinanceiro() {
+  const empresaId = await getEmpresaIdDoUsuario();
+  const snap = await getDocs(
+    query(collection(db, 'empresas', empresaId, 'movimentacoes'), where('tipo', '==', 'entrada'))
+  );
+  entradas = snap.docs.map(doc => {
+    const d = doc.data();
+    const dataMov = d.dataMovimentacao?.toDate?.() || null;
+    const custo = typeof d.custoTotal === 'number'
+      ? d.custoTotal
+      : (Number(d.quantidade) || 0) * (Number(d.precoUnitario) || 0);
+    return {
+      compraId: d.compraId || '-',
+      categoria: d.categoria || '-',
+      custoTotal: custo,
+      dataMovimentacao: dataMov
+    };
+  });
+  return entradas;
+}
+
+function mesesEntre(inicio, fim) {
+  if (!inicio || !fim) return 1;
+  const i = new Date(inicio.getFullYear(), inicio.getMonth(), 1);
+  const f = new Date(fim.getFullYear(), fim.getMonth(), 1);
+  return (f.getFullYear() - i.getFullYear()) * 12 + (f.getMonth() - i.getMonth()) + 1;
+}
+
+export function gerarTabelaFinanceiroCategorias(finDados) {
+  const cont = document.getElementById('tabela-fin-categorias');
+  if (!cont) return;
+
+  const inicioStr = document.getElementById('fin-data-inicio').value;
+  const fimStr = document.getElementById('fin-data-fim').value;
+  const inicioData = inicioStr ? parseDataLocal(inicioStr) : null;
+  const fimData = fimStr ? parseDataLocal(fimStr) : null;
+
+  const compraIds = finDados.map(d => d.compraId);
+  const totais = {};
+  let minData = null;
+  let maxData = null;
+
+  entradas.forEach(e => {
+    if (!compraIds.includes(e.compraId)) return;
+    const data = e.dataMovimentacao;
+    if (inicioData && data && data < inicioData) return;
+    if (fimData && data && data > fimData) return;
+
+    const cat = e.categoria || '-';
+    const val = e.custoTotal || 0;
+    totais[cat] = (totais[cat] || 0) + val;
+
+    if (data) {
+      if (!minData || data < minData) minData = data;
+      if (!maxData || data > maxData) maxData = data;
+    }
+  });
+
+  const categorias = Object.keys(totais);
+  if (categorias.length === 0) {
+    cont.innerHTML = '<p>❌ Nenhum dado encontrado.</p>';
+    return;
+  }
+
+  const meses = inicioData && fimData ? mesesEntre(inicioData, fimData) : mesesEntre(minData, maxData);
+
+  let html = `<table class="tabela"><thead><tr><th>Categoria</th><th>Total Gasto</th><th>Custo Médio por Mês</th></tr></thead><tbody>`;
+  categorias.sort().forEach(cat => {
+    const total = totais[cat];
+    const medio = total / (meses || 1);
+    html += `<tr><td>${cat}</td><td>R$ ${total.toFixed(2)}</td><td>R$ ${medio.toFixed(2)}</td></tr>`;
+  });
+  html += '</tbody></table>';
+  cont.innerHTML = html;
+}
+

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -2,6 +2,7 @@
 
 import { normalizarTexto, parseDataLocal } from '../utils.js';
 import { atualizarCardsFinanceiro } from './financeiroTotais.js';
+import { gerarTabelaFinanceiroCategorias } from './financeiroCategorias.js';
 
 let dados = [];
 let filtrosIniciados = false;
@@ -153,4 +154,5 @@ export function gerarTabelaFinanceiro() {
   lista.innerHTML = html;
 
   atualizarCardsFinanceiro(filtrados);
+  gerarTabelaFinanceiroCategorias(filtrados);
 }


### PR DESCRIPTION
## Summary
- show category summary in Financeiro page
- add module to compute expenses by product category
- update finance scripts to load entries and render grouped table

## Testing
- `node -e "import('./js/relatorios/financeiroCategorias.js')"` *(fails: Only URLs with a scheme in: file and data are supported)*

------
https://chatgpt.com/codex/tasks/task_e_686587eba1c0832b8e81a3468d8d6d77