### PR TITLE
Mostrar valor em aberto no relatório financeiro

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -217,7 +217,9 @@ table {
 }
 
 #tabela-financeiro th:nth-child(5),
-#tabela-financeiro td:nth-child(5) {
+#tabela-financeiro td:nth-child(5),
+#tabela-financeiro th:nth-child(6),
+#tabela-financeiro td:nth-child(6) {
   text-align: right;
 }
 
@@ -277,6 +279,9 @@ table tbody tr:hover {
 .resumo-card.pago { background-color: #eafaf1; }
 .resumo-card.pendente { background-color: #fff8e6; }
 .resumo-card.vencido { background-color: #fdecea; }
+.valor-aberto {
+  color: #f39c12;
+}
 
 .resumo-card .titulo { font-size: 14px; color: #6b7280; }
 .resumo-card .valor { font-size: 20px; font-weight: 600; }

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -23,6 +23,16 @@ function formatarResumoParcelas(parcelas = []) {
     .join('<br>');
 }
 
+function calcularValorAberto(registro) {
+  const parcelas = Array.isArray(registro.parcelas) && registro.parcelas.length > 0
+    ? registro.parcelas
+    : [{ valor: registro.valor, status: registro.status }];
+  return parcelas.reduce((s, p) => {
+    const v = Number(p.valor) || 0;
+    return p.status === 'pago' ? s : s + v;
+  }, 0);
+}
+
 // 🔥 Setar dados
 export function setDadosFinanceiro(novosDados) {
   dados = novosDados;
@@ -143,6 +153,7 @@ export function gerarTabelaFinanceiro() {
           <th>Data da compra</th>
           <th>Forma de pagamento</th>
           <th>Valor total</th>
+          <th>Valor em aberto</th>
           <th>Parcelas</th>
         </tr>
       </thead>
@@ -151,6 +162,7 @@ export function gerarTabelaFinanceiro() {
 
   filtrados.forEach(d => {
     const lanc = d.dataLancamento?.toLocaleDateString('pt-BR') || '-';
+    const aberto = calcularValorAberto(d);
     html += `
       <tr>
         <td>${d.compraId}</td>
@@ -158,6 +170,7 @@ export function gerarTabelaFinanceiro() {
         <td>${lanc}</td>
         <td>${d.formaPagamento}</td>
         <td>R$ ${(d.valor).toFixed(2)}</td>
+        <td class="valor-aberto">R$ ${aberto.toFixed(2)}</td>
         <td>
           ${formatarResumoParcelas(d.parcelas)}<br>
           <button onclick="abrirModalParcelas('${d.compraId}')">Ver</button>


### PR DESCRIPTION
## Summary
- compute open value for each purchase
- display `Valor em aberto` column in the finance table
- style outstanding value with orange color

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865b541f95c832ba3cd5c5f16d41329