### PR TITLE
Adjust Financeiro table header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -216,6 +216,12 @@ table {
   width: 140px;
 }
 
+#tabela-financeiro th:nth-child(4),
+#tabela-financeiro td:nth-child(4) {
+  min-width: 120px;
+  white-space: normal;
+}
+
 #tabela-financeiro th:nth-child(5),
 #tabela-financeiro td:nth-child(5),
 #tabela-financeiro th:nth-child(6),

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -151,7 +151,7 @@ export function gerarTabelaFinanceiro() {
           <th>CompraID</th>
           <th>Fornecedor</th>
           <th>Data da compra</th>
-          <th>Forma de pagamento</th>
+          <th>Forma<br>de Pagamento</th>
           <th>Valor total</th>
           <th>Valor em aberto</th>
           <th>Parcelas</th>


### PR DESCRIPTION
## Summary
- wrap the finance report "Forma de Pagamento" header text to use two lines
- shrink the minimum width of the payment column

## Testing
- `npm test --silent` *(fails: no tests defined / network access)*

------
https://chatgpt.com/codex/tasks/task_e_6865b676c7b4832b9b992bc3779b9f84