### PR TITLE
Truncate fornecedor names in financial table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -235,6 +235,13 @@ th, td {
   text-align: left;
 }
 
+.fornecedor-cell {
+  max-width: 20ch;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 th {
   background-color: #fafafa;
 }

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -163,10 +163,15 @@ export function gerarTabelaFinanceiro() {
   filtrados.forEach(d => {
     const lanc = d.dataLancamento?.toLocaleDateString('pt-BR') || '-';
     const aberto = calcularValorAberto(d);
+    const nomeFornecedor = d.fornecedorOuCliente || '-';
+    const fornecedorEscapado = nomeFornecedor.replace(/"/g, '&quot;');
+    const fornecedorCurto = nomeFornecedor.length > 20
+      ? nomeFornecedor.slice(0, 20) + '...'
+      : nomeFornecedor;
     html += `
       <tr>
         <td>${d.compraId}</td>
-        <td>${d.fornecedorOuCliente}</td>
+        <td class="fornecedor-cell" title="${fornecedorEscapado}">${fornecedorCurto}</td>
         <td>${lanc}</td>
         <td>${d.formaPagamento}</td>
         <td>R$ ${(d.valor).toFixed(2)}</td>


### PR DESCRIPTION
## Summary
- shorten long supplier names in financial table with ellipsis
- add CSS style for truncated text

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865b752d0c8832bbe4d85327848e3e9