### PR TITLE
Melhora visual do compraId nas tabelas

### DIFF
--- a/js/relatorios/entradasTabela.js
+++ b/js/relatorios/entradasTabela.js
@@ -1,4 +1,4 @@
-import { normalizarTexto, parseDataLocal } from '../utils.js';
+import { normalizarTexto, parseDataLocal, formatarCompraIdCurto } from '../utils.js';
 import { atualizarCardsEntradas } from './entradasTotais.js';
 import { gerarGraficoEntradas } from './entradasGraficos.js';
 
@@ -127,7 +127,7 @@ function aplicarFiltros() {
         <td>${validade}</td>
         <td>${d.preco.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
         <td>${d.fornecedor}</td>
-        ${mostrarCompraId ? `<td>${d.compraId}</td>` : ''}
+        ${mostrarCompraId ? `<td>${formatarCompraIdCurto(d.compraId)}</td>` : ''}
         <td>${data}</td>
         <td><button onclick="abrirModalDetalhesEntrada('${d.id}')">Ver Detalhes</button></td>
       </tr>

--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -4,7 +4,7 @@ import { carregarDadosFinanceiro } from './financeiroDados.js';
 import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro, dadosFiltradosFinanceiro } from './financeiroTabela.js';
 import { carregarEntradasFinanceiro } from './financeiroCategorias.js';
 import { exportarFinanceiroCSV, exportarFinanceiroExcel, exportarFinanceiroPDF } from './financeiroExportar.js';
-import { mostrarSpinner, esconderSpinner, mostrarMensagem, parseDataBR } from '../utils.js';
+import { mostrarSpinner, esconderSpinner, mostrarMensagem, parseDataBR, formatarCompraIdCurto } from '../utils.js';
 import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where, doc, updateDoc } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
@@ -117,7 +117,7 @@ window.abrirModalParcelas = async function (compraId) {
   const registro = dadosFinanceiro.find(d => d.compraId === compraId);
   if (!registro) return;
 
-  document.getElementById('modal-compra-id').textContent = compraId;
+  document.getElementById('modal-compra-id').textContent = formatarCompraIdCurto(compraId);
   const cont = document.getElementById('parcelas-detalhes');
 
   let html = '';

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -1,6 +1,6 @@
 // financeiroTabela.js — Geração de tabela e filtros
 
-import { normalizarTexto, parseDataLocal } from '../utils.js';
+import { normalizarTexto, parseDataLocal, formatarCompraIdCurto } from '../utils.js';
 import { atualizarCardsFinanceiro } from './financeiroTotais.js';
 import { gerarTabelaFinanceiroCategorias } from './financeiroCategorias.js';
 
@@ -170,7 +170,7 @@ export function gerarTabelaFinanceiro() {
       : nomeFornecedor;
     html += `
       <tr>
-        <td>${d.compraId}</td>
+        <td>${formatarCompraIdCurto(d.compraId)}</td>
         <td class="fornecedor-cell" title="${fornecedorEscapado}">${fornecedorCurto}</td>
         <td>${lanc}</td>
         <td>${d.formaPagamento}</td>

--- a/js/utils.js
+++ b/js/utils.js
@@ -124,3 +124,13 @@ export function calcularDiasParaVencimento(validade) {
     return Infinity;
   }
 }
+
+// 👉 Formatar compraId em formato curto (ex: "#1 (30/06/2025)")
+export function formatarCompraIdCurto(id) {
+  if (!id || typeof id !== 'string') return id;
+  const m = id.match(/compra_(\d{4})-?(\d{2})-?(\d{2})_(\d+)/);
+  if (!m) return id;
+  const [, ano, mes, dia, numeroRaw] = m;
+  const numero = String(Number(numeroRaw));
+  return `#${numero} (${dia}/${mes}/${ano})`;
+}


### PR DESCRIPTION
## Resumo
- mostrar compraId em formato curto nas tabelas de entradas e financeiro
- exibir compraId curto no modal de parcelas
- adicionar utilitário `formatarCompraIdCurto`

## Testes
- `npm test` *(falha: não há package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865bf5ffff8832ba5a25c5b3e5491d9