### PR TITLE
Ajuste largura filtros financeiro

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -476,6 +476,29 @@ table tbody tr:hover {
   box-sizing: border-box;
 }
 
+/* Ajustes de largura para filtros do financeiro */
+.filtros-financeiro {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 20px;
+  padding: 10px;
+  border: 1px solid #eee;
+  border-radius: 6px;
+}
+.filtros-financeiro .campo-filtro {
+  flex: 1 1 180px;
+}
+.filtros-financeiro .campo-filtro.estreito {
+  flex: 1 1 120px;
+  max-width: 160px;
+}
+.filtros-financeiro .campo-filtro.estreito select {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Grupo de botões nos filtros */
 .botoes {
   display: flex;

--- a/financeiro.html
+++ b/financeiro.html
@@ -29,12 +29,12 @@
     <h1>💰 Financeiro</h1>
     <div id="alerta-vencidas" class="alert-aviso" style="display:none; margin-bottom:10px;"></div>
 
-    <div class="filtros">
-      <div class="campo-filtro">
+    <div class="filtros filtros-financeiro">
+      <div class="campo-filtro estreito">
         <label for="fin-data-inicio">De</label>
         <input type="date" id="fin-data-inicio">
       </div>
-      <div class="campo-filtro">
+      <div class="campo-filtro estreito">
         <label for="fin-data-fim">Até</label>
         <input type="date" id="fin-data-fim">
       </div>
@@ -44,11 +44,11 @@
         <input type="text" id="fin-compra-id" placeholder="Buscar..." list="lista-compra-fin">
         <datalist id="lista-compra-fin"></datalist>
       </div>
-      <div class="campo-filtro">
+      <div class="campo-filtro estreito">
         <label for="fin-fornecedor">Fornecedor</label>
         <select id="fin-fornecedor"></select>
       </div>
-      <div class="campo-filtro">
+      <div class="campo-filtro estreito">
         <label for="fin-forma">Forma</label>
         <select id="fin-forma"></select>
       </div>


### PR DESCRIPTION
## Summary
- reduce filter widths on financeiro report
- add flexible layout for finance filters

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c6463858832b99209157674a9506