### PR TITLE
Implement text truncation for Fornecedor and CompraId

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -267,6 +267,12 @@ th, td {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.compra-id-cell {
+  max-width: 20ch;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 th {
   background-color: #fafafa;

--- a/js/estoque/estoqueUnificado.js
+++ b/js/estoque/estoqueUnificado.js
@@ -185,6 +185,9 @@ function renderizarTabela() {
     const dias = calculaPrevisao(d);
     const classe = d.quantidade < d.quantidadeMinima ?
       (document.getElementById('filtro-critico').checked ? 'critico' : 'critico-suave') : '';
+    const fornTxt = d.fornecedor || '-';
+    const fornEsc = fornTxt.replace(/"/g, '&quot;');
+    const fornCurto = fornTxt.length > 20 ? fornTxt.slice(0, 20) + '...' : fornTxt;
     html += `<tr class="${classe}">
       <td>${d.nome}</td>
       <td>${d.quantidade}</td>
@@ -196,7 +199,7 @@ function renderizarTabela() {
       <td>${dias}</td>
       <td>${d.validade}</td>
       <td>${d.categoria}</td>
-      <td>${d.fornecedor}</td>
+      <td class="fornecedor-cell" title="${fornEsc}">${fornCurto}</td>
     </tr>`;
   });
 

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -248,7 +248,7 @@ function renderizarTabela(produtos, termo = "") {
         <td>${precoMax}</td>
         <td>${precoMed}</td>
         <td>${dataValidade}</td>
-        <td>${p.fornecedor || "-"}</td>
+        <td class="fornecedor-cell" title="${(p.fornecedor || '-').replace(/"/g, '&quot;')}">${(p.fornecedor || '-').length > 20 ? (p.fornecedor || '-').slice(0, 20) + '...' : (p.fornecedor || '-')}</td>
         <td>${p.localizacao || "-"}</td>
         <td>
           <button onclick="verDetalhes('${p.id}')">👁️ Detalhes</button>

--- a/js/relatorios/consumoTabela.js
+++ b/js/relatorios/consumoTabela.js
@@ -49,6 +49,9 @@ function aplicarFiltrosEAtualizarTabela() {
 
   filtrados.forEach(d => {
     const mesAno = d.data ? `${String(d.data.getMonth()+1).padStart(2,'0')}/${d.data.getFullYear()}` : "-";
+    const fornTxt = d.fornecedor || '-';
+    const fornEsc = fornTxt.replace(/"/g, '&quot;');
+    const fornCurto = fornTxt.length > 20 ? fornTxt.slice(0, 20) + '...' : fornTxt;
     html += `
       <tr>
         <td>${d.nome}</td>
@@ -56,7 +59,7 @@ function aplicarFiltrosEAtualizarTabela() {
         <td>${(d.quantidade || 0).toLocaleString('pt-BR')}</td>
         <td>${d.unidade}</td>
         <td>${d.categoria}</td>
-        <td>${d.fornecedor}</td>
+        <td class="fornecedor-cell" title="${fornEsc}">${fornCurto}</td>
       </tr>
     `;
   });

--- a/js/relatorios/entradasTabela.js
+++ b/js/relatorios/entradasTabela.js
@@ -120,14 +120,19 @@ function aplicarFiltros() {
     let tooltip = `Usuário: ${d.usuario || '-'}\nObs.: ${d.observacoes || 'Nenhuma'}\nModificado: ${modificado}`;
     tooltip = tooltip.replace(/"/g, '&quot;');
 
+    const fornTxt = d.fornecedor || '-';
+    const fornEsc = fornTxt.replace(/"/g, '&quot;');
+    const fornCurto = fornTxt.length > 20 ? fornTxt.slice(0, 20) + '...' : fornTxt;
+    const compraEsc = (d.compraId || '').replace(/"/g, '&quot;');
+
     html += `
       <tr title="${tooltip}">
         <td>${d.nome}</td>
         <td>${d.quantidade}</td>
         <td>${validade}</td>
         <td>${d.preco.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
-        <td>${d.fornecedor}</td>
-        ${mostrarCompraId ? `<td>${formatarCompraIdCurto(d.compraId)}</td>` : ''}
+        <td class="fornecedor-cell" title="${fornEsc}">${fornCurto}</td>
+        ${mostrarCompraId ? `<td class="compra-id-cell" title="${compraEsc}">${formatarCompraIdCurto(d.compraId)}</td>` : ''}
         <td>${data}</td>
         <td><button onclick="abrirModalDetalhesEntrada('${d.id}')">Ver Detalhes</button></td>
       </tr>

--- a/js/relatorios/estoqueTabela.js
+++ b/js/relatorios/estoqueTabela.js
@@ -84,6 +84,9 @@ export function gerarTabelaEstoque() {
     else if (validadeProxima) cor = "background:#fff4e5;"; // laranja claro
     else if (estoqueCritico) cor = "background:#fffbe5;"; // amarelo claro
 
+    const fornTxt = p.fornecedor || '-';
+    const fornEsc = fornTxt.replace(/"/g, '&quot;');
+    const fornCurto = fornTxt.length > 20 ? fornTxt.slice(0, 20) + '...' : fornTxt;
     html += `
       <tr style="${cor}">
         <td>${p.nome}</td>
@@ -92,7 +95,7 @@ export function gerarTabelaEstoque() {
         <td>${validadeFormatada}</td>
         <td>${p.diasParaVencer ?? "-"}</td>
         <td>${p.categoria}</td>
-        <td>${p.fornecedor}</td>
+        <td class="fornecedor-cell" title="${fornEsc}">${fornCurto}</td>
       </tr>
     `;
   });

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -168,9 +168,10 @@ export function gerarTabelaFinanceiro() {
     const fornecedorCurto = nomeFornecedor.length > 20
       ? nomeFornecedor.slice(0, 20) + '...'
       : nomeFornecedor;
+    const compraEscapado = (d.compraId || '').replace(/"/g, '&quot;');
     html += `
       <tr>
-        <td>${formatarCompraIdCurto(d.compraId)}</td>
+        <td class="compra-id-cell" title="${compraEscapado}">${formatarCompraIdCurto(d.compraId)}</td>
         <td class="fornecedor-cell" title="${fornecedorEscapado}">${fornecedorCurto}</td>
         <td>${lanc}</td>
         <td>${d.formaPagamento}</td>

--- a/js/relatorios/previsaoTabela.js
+++ b/js/relatorios/previsaoTabela.js
@@ -64,11 +64,14 @@ export function gerarTabelaPrevisao() {
     const dataUltima = p.ultimaSaida ? p.ultimaSaida.toLocaleDateString('pt-BR') : "-";
     const classe = p.diasDeEstoque !== Infinity && p.diasDeEstoque <= 15 ? 'critico' : '';
 
+    const fornTxt = p.fornecedor || '-';
+    const fornEsc = fornTxt.replace(/"/g, '&quot;');
+    const fornCurto = fornTxt.length > 20 ? fornTxt.slice(0, 20) + '...' : fornTxt;
     html += `
       <tr class="${classe}">
         <td>${p.nome}</td>
         <td>${p.categoria}</td>
-        <td>${p.fornecedor}</td>
+        <td class="fornecedor-cell" title="${fornEsc}">${fornCurto}</td>
         <td>${p.quantidade}</td>
         <td>${p.consumoMensal}</td>
         <td>${p.mediaDiasPorUnidade ?? '-'}</td>


### PR DESCRIPTION
## Summary
- add `compra-id-cell` CSS class for ellipsis
- truncate Fornecedor and CompraId columns across report tables

## Testing
- `npm test --silent || true`
- `(from functions directory)` `npm test --silent || true`

------
https://chatgpt.com/codex/tasks/task_e_6865c74a623c832b93ad02b41b3166cb