### PR TITLE
Show active filters on financeiro cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -646,3 +646,9 @@ button.btn-icon.btn-sm { font-size: 13px; padding: 5px; }
 button.btn-icon.btn-md { font-size: 14px; padding: 6px; }
 button.btn-icon.btn-lg { font-size: 15px; padding: 7px; }
 button.btn-icon.btn-xl { font-size: 16px; padding: 8px; }
+
+/* Descrição de filtros aplicados */
+.descricao-filtros {
+  margin: 10px 0;
+  color: #6b7280;
+}

--- a/financeiro.html
+++ b/financeiro.html
@@ -70,6 +70,8 @@
       </div>
     </div>
 
+    <p id="descricao-filtros-fin" class="descricao-filtros"></p>
+
     <div id="cards-financeiro" class="cards">
       <div class="resumo-card" id="card-total-comprado">
         <div class="icone">💸</div>

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -7,6 +7,32 @@ import { gerarTabelaFinanceiroCategorias } from './financeiroCategorias.js';
 let dados = [];
 let filtrosIniciados = false;
 
+// 📝 Atualizar descrição dos filtros aplicados
+export function atualizarDescricaoFiltrosFinanceiro() {
+  const inicio = document.getElementById('fin-data-inicio').value;
+  const fim = document.getElementById('fin-data-fim').value;
+  const forma = document.getElementById('fin-forma').value;
+  const fornecedor = document.getElementById('fin-fornecedor').value;
+  const status = document.getElementById('fin-status').value;
+  const categoria = document.getElementById('fin-categoria-prod').value;
+  const compraId = document.getElementById('fin-compra-id').value.trim();
+
+  const partes = [];
+  if (inicio || fim) partes.push(`entre ${inicio || '...'} e ${fim || '...'}`);
+  if (forma) partes.push(`forma de pagamento: ${forma}`);
+  if (fornecedor) partes.push(`fornecedor: ${fornecedor}`);
+  if (compraId) partes.push(`CompraID: ${compraId}`);
+  if (categoria) partes.push(`categoria: ${categoria}`);
+  if (status) partes.push(`status: ${status}`);
+
+  const texto = partes.length > 0
+    ? `Exibindo dados de compras ${partes.join(', ')}.`
+    : 'Exibindo todos os dados de compras.';
+
+  const el = document.getElementById('descricao-filtros-fin');
+  if (el) el.textContent = texto;
+}
+
 function formatarResumoParcelas(parcelas = []) {
   if (!Array.isArray(parcelas) || parcelas.length === 0) return '-';
   const total = parcelas.length;
@@ -141,6 +167,7 @@ export function gerarTabelaFinanceiro() {
   if (filtrados.length === 0) {
     lista.innerHTML = "<p>❌ Nenhum dado encontrado.</p>";
     atualizarCardsFinanceiro([]);
+    atualizarDescricaoFiltrosFinanceiro();
     return;
   }
 
@@ -190,4 +217,5 @@ export function gerarTabelaFinanceiro() {
 
   atualizarCardsFinanceiro(filtrados);
   gerarTabelaFinanceiroCategorias(filtrados);
+  atualizarDescricaoFiltrosFinanceiro();
 }


### PR DESCRIPTION
## Summary
- display an empty paragraph to show active filters
- style the filter description
- update finance table script to output current filters

## Testing
- `npm test` *(fails: Missing script & no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6865c927d080832b87371e3be098c118