### PR TITLE
Implement similar-name suggestions in Produtos form

### DIFF
--- a/js/produtos.js
+++ b/js/produtos.js
@@ -31,7 +31,8 @@ import {
   mostrarErro,
   calcularDiasParaVencimento,
   executarComSpinner,
-  parseDataLocal
+  parseDataLocal,
+  distanciaLevenshtein
 } from './utils.js';
 
 // 🔧 Formatador de datas
@@ -71,6 +72,10 @@ let produtoEmEdicao = null;
 let docRefEmEdicao = null;
 let metricasPrecoPorNome = {};
 let quantidadeTotalPorNome = {};
+let nomesProdutosUnicos = [];
+let timeoutSugestaoNome = null;
+let indiceSugestaoNome = -1;
+let itensSugestaoNome = [];
 
 
 // ==========================
@@ -88,6 +93,7 @@ async function carregarProdutos() {
     // console.log(`✅ Produtos carregados: ${snapshot.docs.length}`);
 
     produtosCache = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    nomesProdutosUnicos = [...new Set(produtosCache.map(p => p.nome))];
 
     quantidadeTotalPorNome = {};
     produtosCache.forEach(p => {
@@ -531,7 +537,84 @@ async function carregarSugestoes() {
   document.getElementById("lista-fornecedores").innerHTML =
     [...fornecedores].sort().map(f => `<option value="${f}">`).join("");
 }
+
 carregarSugestoes();
+
+// ==========================
+// 🔍 Autocomplete de Nome
+// ==========================
+const inputNomeProduto = document.getElementById('nome');
+const listaSugestoesNome = document.getElementById('sugestoes-nome');
+
+inputNomeProduto.addEventListener('input', () => {
+  const termoOriginal = inputNomeProduto.value.trim();
+  const termo = normalizarTexto(termoOriginal);
+  if (listaSugestoesNome) {
+    listaSugestoesNome.innerHTML = '';
+    listaSugestoesNome.style.display = 'none';
+  }
+  indiceSugestaoNome = -1;
+  itensSugestaoNome = [];
+
+  if (termo.length < 2) return;
+
+  clearTimeout(timeoutSugestaoNome);
+  timeoutSugestaoNome = setTimeout(() => {
+    const encontrados = nomesProdutosUnicos.filter(n => {
+      const norm = normalizarTexto(n);
+      if (norm.includes(termo) || termo.includes(norm)) return true;
+      return distanciaLevenshtein(norm, termo) <= 2;
+    });
+
+    if (encontrados.length && listaSugestoesNome) {
+      encontrados.slice(0, 10).forEach(n => {
+        const item = document.createElement('li');
+        item.textContent = n;
+        item.className = 'autocomplete-item';
+        item.addEventListener('click', () => {
+          inputNomeProduto.value = n;
+          listaSugestoesNome.innerHTML = '';
+          listaSugestoesNome.style.display = 'none';
+          if (confirm('⚠️ Um produto com nome semelhante já existe. Deseja ir para a aba de Movimentações para dar entrada ou saída neste item?')) {
+            sessionStorage.setItem('nomeProdutoMovimentacao', n);
+            window.location.href = 'movimentacoes.html';
+          }
+        });
+        listaSugestoesNome.appendChild(item);
+        itensSugestaoNome.push(item);
+      });
+      listaSugestoesNome.style.display = 'block';
+    }
+  }, 300);
+});
+
+inputNomeProduto.addEventListener('keydown', e => {
+  if (!listaSugestoesNome || itensSugestaoNome.length === 0) return;
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    if (indiceSugestaoNome < itensSugestaoNome.length - 1) {
+      indiceSugestaoNome++;
+      atualizarSelecaoNome();
+    }
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (indiceSugestaoNome > 0) {
+      indiceSugestaoNome--;
+      atualizarSelecaoNome();
+    }
+  } else if (e.key === 'Enter' || e.key === 'Tab') {
+    if (indiceSugestaoNome >= 0 && indiceSugestaoNome < itensSugestaoNome.length) {
+      e.preventDefault();
+      itensSugestaoNome[indiceSugestaoNome].click();
+    }
+  }
+});
+
+function atualizarSelecaoNome() {
+  itensSugestaoNome.forEach((item, index) => {
+    item.classList.toggle('selecionado', index === indiceSugestaoNome);
+  });
+}
 
 // ==========================
 // 🔥 Alerta ao Perder Foco

--- a/js/utils.js
+++ b/js/utils.js
@@ -13,6 +13,28 @@ export function normalizarTexto(str) {
     .toLowerCase();
 }
 
+// 👉 Distância de Levenshtein simples
+export function distanciaLevenshtein(a = "", b = "") {
+  const m = a.length;
+  const n = b.length;
+  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const custo = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + custo
+      );
+    }
+  }
+  return dp[m][n];
+}
+
 // ==========================
 // 🔔 Mensagens
 // ==========================

--- a/produtos.html
+++ b/produtos.html
@@ -34,9 +34,10 @@
       <section class="form-section">
         <h2>Registrar Produto</h2>
         <form id="form-produto" class="form-grid">
-          <div class="form-group">
+          <div class="form-group" style="position: relative;">
             <label>Nome:</label>
             <input type="text" id="nome" required />
+            <ul id="sugestoes-nome" class="autocomplete-list"></ul>
           </div>
 
           <div class="form-group">


### PR DESCRIPTION
## Summary
- add autocomplete list for product names in produtos.html
- expose `distanciaLevenshtein` in utils for fuzzy search
- show suggestions as user types and allow quick jump to Movimentações

## Testing
- `node -c js/produtos.js`
- `node -c js/utils.js`

------
https://chatgpt.com/codex/tasks/task_e_6865d47e6b44832b99f3eff398bef993