### PR TITLE
Add financial operations summary

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -29,6 +29,41 @@
     <h1>💰 Financeiro</h1>
     <div id="alerta-vencidas" class="alert-aviso" style="display:none; margin-bottom:10px;"></div>
 
+    <section id="operacoes-periodo" style="margin-bottom:20px;">
+      <h2>Operações financeiras por período</h2>
+      <div id="cards-operacoes-periodo" class="cards">
+        <div class="resumo-card" id="card-produtos-comprados">
+          <div class="icone">📥</div>
+          <div class="texto">
+            <div class="titulo text-sm text-gray-500">Produtos comprados</div>
+            <div class="valor text-xl font-semibold" id="valor-produtos-comprados">-</div>
+          </div>
+        </div>
+        <div class="resumo-card" id="card-produtos-consumidos">
+          <div class="icone">📦</div>
+          <div class="texto">
+            <div class="titulo text-sm text-gray-500">Produtos consumidos</div>
+            <div class="valor text-xl font-semibold" id="valor-produtos-consumidos">-</div>
+          </div>
+        </div>
+        <div class="resumo-card" id="card-valor-compras">
+          <div class="icone">💰</div>
+          <div class="texto">
+            <div class="titulo text-sm text-gray-500">Valor total gasto</div>
+            <div class="valor text-xl font-semibold" id="valor-gasto-compras">-</div>
+          </div>
+        </div>
+        <div class="resumo-card" id="card-valor-saidas-periodo">
+          <div class="icone">💸</div>
+          <div class="texto">
+            <div class="titulo text-sm text-gray-500">Valor total em saídas</div>
+            <div class="valor text-xl font-semibold" id="valor-total-saidas">-</div>
+          </div>
+        </div>
+      </div>
+      <canvas id="grafico-operacoes" style="max-height:300px; margin-top:10px;"></canvas>
+    </section>
+
     <div class="filtros filtros-financeiro">
       <div class="campo-filtro estreito">
         <label for="fin-data-inicio">De</label>
@@ -140,6 +175,7 @@
 <script type="module" src="js/utils.js"></script>
 <script type="module" src="js/modais.js"></script>
 <script type="module" src="js/relatorios/financeiro.js"></script>
+<script type="module" src="js/relatorios/financeiroOperacoes.js"></script>
 <script type="module" src="js/relatorios/financeiroExportar.js"></script>
 <script type="module" src="js/relatorios/financeiroGraficos.js"></script>
 <script type="module" src="js/relatorios/financeiroTotais.js"></script>

--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -3,6 +3,7 @@
 import { carregarDadosFinanceiro } from './financeiroDados.js';
 import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro, dadosFiltradosFinanceiro } from './financeiroTabela.js';
 import { carregarEntradasFinanceiro } from './financeiroCategorias.js';
+import { carregarOperacoes } from './financeiroOperacoes.js';
 import { exportarFinanceiroCSV, exportarFinanceiroExcel, exportarFinanceiroPDF } from './financeiroExportar.js';
 import { mostrarSpinner, esconderSpinner, mostrarMensagem, parseDataBR, formatarCompraIdCurto } from '../utils.js';
 import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
@@ -66,6 +67,7 @@ export async function atualizarTabelaFinanceiro() {
 
     dadosFinanceiro = await carregarDadosFinanceiro();
     entradasFinanceiro = await carregarEntradasFinanceiro();
+    await carregarOperacoes();
 
     setDadosFinanceiro(dadosFinanceiro);
     gerarFiltrosFinanceiro();

--- a/js/relatorios/financeiroOperacoes.js
+++ b/js/relatorios/financeiroOperacoes.js
@@ -1,0 +1,110 @@
+import { carregarDadosEntradas } from './entradasDados.js';
+import { carregarDadosConsumo } from './consumoDados.js';
+import { parseDataLocal } from '../utils.js';
+
+let entradas = [];
+let saidas = [];
+let grafico = null;
+
+export async function carregarOperacoes() {
+  entradas = await carregarDadosEntradas();
+  saidas = await carregarDadosConsumo();
+}
+
+function filtrar(lista, inicio, fim, categoria, fornecedor) {
+  return lista.filter(item => {
+    const data = item.data;
+    if (inicio && data && data < inicio) return false;
+    if (fim && data && data > fim) return false;
+    if (categoria && item.categoria !== categoria) return false;
+    if (fornecedor && item.fornecedor !== fornecedor) return false;
+    return true;
+  });
+}
+
+function formatarMes(chave) {
+  const [ano, mes] = chave.split('-');
+  return `${mes}/${ano}`;
+}
+
+function gerarGrafico(entradasFiltradas, saidasFiltradas) {
+  const canvas = document.getElementById('grafico-operacoes');
+  if (!canvas || typeof Chart === 'undefined') return;
+  const ctx = canvas.getContext('2d');
+  if (grafico) grafico.destroy();
+
+  const mesesSet = new Set();
+  entradasFiltradas.forEach(e => {
+    if (e.data) mesesSet.add(`${e.data.getFullYear()}-${String(e.data.getMonth()+1).padStart(2,'0')}`);
+  });
+  saidasFiltradas.forEach(s => {
+    if (s.data) mesesSet.add(`${s.data.getFullYear()}-${String(s.data.getMonth()+1).padStart(2,'0')}`);
+  });
+  const meses = Array.from(mesesSet).sort();
+
+  const dadosEntradas = meses.map(m => entradasFiltradas.filter(e => e.data && `${e.data.getFullYear()}-${String(e.data.getMonth()+1).padStart(2,'0')}` === m).reduce((a,c) => a + (c.quantidade || 0), 0));
+  const dadosSaidas = meses.map(m => saidasFiltradas.filter(s => s.data && `${s.data.getFullYear()}-${String(s.data.getMonth()+1).padStart(2,'0')}` === m).reduce((a,c) => a + (c.quantidade || 0), 0));
+
+  grafico = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: meses.map(formatarMes),
+      datasets: [
+        {
+          label: 'Entradas',
+          data: dadosEntradas,
+          borderColor: '#3b82f6',
+          backgroundColor: 'transparent',
+          tension: 0.2,
+          pointRadius: 3
+        },
+        {
+          label: 'Saídas',
+          data: dadosSaidas,
+          borderColor: '#ef4444',
+          backgroundColor: 'transparent',
+          tension: 0.2,
+          pointRadius: 3
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: false }, title: { display: false } },
+      scales: {
+        x: { grid: { display: false }, ticks: { color: '#6b7280', font: { size: 12 } } },
+        y: { beginAtZero: true, grid: { color: '#e5e7eb' }, ticks: { color: '#6b7280', font: { size: 12 } } }
+      }
+    }
+  });
+}
+
+export function atualizarOperacoesPeriodo() {
+  const inicioStr = document.getElementById('fin-data-inicio').value;
+  const fimStr = document.getElementById('fin-data-fim').value;
+  const categoria = document.getElementById('fin-categoria-prod').value;
+  const fornecedor = document.getElementById('fin-fornecedor').value;
+  const inicio = inicioStr ? parseDataLocal(inicioStr) : null;
+  const fim = fimStr ? parseDataLocal(fimStr) : null;
+
+  const entradasFiltradas = filtrar(entradas, inicio, fim, categoria, fornecedor);
+  const saidasFiltradas = filtrar(saidas, inicio, fim, categoria, fornecedor);
+
+  const prodComprados = entradasFiltradas.reduce((s,e) => s + (e.quantidade || 0), 0);
+  const valorCompras = entradasFiltradas.reduce((s,e) => s + (e.quantidade || 0)*(e.preco || 0), 0);
+  const prodConsumidos = saidasFiltradas.reduce((s,sai) => s + (sai.quantidade || 0), 0);
+  const valorSaidas = saidasFiltradas.reduce((s,sai) => s + (sai.custoTotal || (sai.quantidade || 0)*(sai.precoUnitario || 0)), 0);
+
+  document.getElementById('valor-produtos-comprados').textContent = prodComprados.toLocaleString('pt-BR');
+  document.getElementById('valor-produtos-consumidos').textContent = prodConsumidos.toLocaleString('pt-BR');
+  document.getElementById('valor-gasto-compras').textContent = valorCompras.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  document.getElementById('valor-total-saidas').textContent = valorSaidas.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+  gerarGrafico(entradasFiltradas, saidasFiltradas);
+}
+
+// Inicializa ao carregar a página
+document.addEventListener('DOMContentLoaded', async () => {
+  await carregarOperacoes();
+  atualizarOperacoesPeriodo();
+});

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -3,6 +3,7 @@
 import { normalizarTexto, parseDataLocal, formatarCompraIdCurto, formatarDataISOParaBR } from '../utils.js';
 import { atualizarCardsFinanceiro } from './financeiroTotais.js';
 import { gerarTabelaFinanceiroCategorias } from './financeiroCategorias.js';
+import { atualizarOperacoesPeriodo } from './financeiroOperacoes.js';
 
 let dados = [];
 let filtrosIniciados = false;
@@ -253,4 +254,5 @@ export function gerarTabelaFinanceiro() {
   atualizarCardsFinanceiro(filtrados);
   gerarTabelaFinanceiroCategorias(filtrados);
   atualizarDescricaoFiltrosFinanceiro();
+  atualizarOperacoesPeriodo();
 }


### PR DESCRIPTION
## Summary
- add cards for financial operations by period
- calculate purchased and consumed products as well as totals
- show evolution chart for entries and exits

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865e72ebbd4832bab47a54930aaabaa