### PR TITLE
Fix categoria filter and add gastos summary

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -88,7 +88,7 @@
         <select id="fin-forma"></select>
       </div>
       <div class="campo-filtro estreito">
-        <label for="fin-categoria-prod">Categoria prod.</label>
+        <label for="fin-categoria-prod">Categoria</label>
         <select id="fin-categoria-prod" class="campo-categoria"></select>
       </div>
       <div class="campo-filtro">
@@ -140,7 +140,7 @@
 
     <div id="tabela-financeiro"></div>
 
-    <h2 style="margin-top:20px;">Gastos por Categoria de Produto</h2>
+    <h2 style="margin-top:20px;">Gastos por Categoria</h2>
     <div id="tabela-fin-categorias"></div>
 
     <h2 style="margin-top:20px;">Projeção de Pagamentos Futuros</h2>

--- a/js/relatorios/entradasDados.js
+++ b/js/relatorios/entradasDados.js
@@ -18,6 +18,7 @@ export async function carregarDadosEntradas() {
       id: doc.id,
       nome: d.nomeProduto || '-',
       fornecedor: d.fornecedor || '-',
+      categoria: d.categoria || '-',
       quantidade: Number(d.quantidade) || 0,
       validade: d.validade?.toDate() || null,
       preco: Number(d.precoUnitario) || 0,

--- a/js/relatorios/financeiroCategorias.js
+++ b/js/relatorios/financeiroCategorias.js
@@ -20,18 +20,12 @@ export async function carregarEntradasFinanceiro() {
     return {
       compraId: d.compraId || '-',
       categoria: d.categoria || '-',
+      quantidade: Number(d.quantidade) || 0,
       custoTotal: custo,
       dataMovimentacao: dataMov
     };
   });
   return entradas;
-}
-
-function mesesEntre(inicio, fim) {
-  if (!inicio || !fim) return 1;
-  const i = new Date(inicio.getFullYear(), inicio.getMonth(), 1);
-  const f = new Date(fim.getFullYear(), fim.getMonth(), 1);
-  return (f.getFullYear() - i.getFullYear()) * 12 + (f.getMonth() - i.getMonth()) + 1;
 }
 
 export function gerarTabelaFinanceiroCategorias(finDados) {
@@ -55,8 +49,9 @@ export function gerarTabelaFinanceiroCategorias(finDados) {
     if (fimData && data && data > fimData) return;
 
     const cat = e.categoria || '-';
-    const val = e.custoTotal || 0;
-    totais[cat] = (totais[cat] || 0) + val;
+    if (!totais[cat]) totais[cat] = { valor: 0, quantidade: 0 };
+    totais[cat].valor += e.custoTotal || 0;
+    totais[cat].quantidade += e.quantidade || 0;
 
     if (data) {
       if (!minData || data < minData) minData = data;
@@ -66,17 +61,14 @@ export function gerarTabelaFinanceiroCategorias(finDados) {
 
   const categorias = Object.keys(totais);
   if (categorias.length === 0) {
-    cont.innerHTML = '<p>❌ Nenhum dado encontrado.</p>';
+    cont.innerHTML = '<p>Nenhum gasto encontrado nesta categoria no período selecionado.</p>';
     return;
   }
 
-  const meses = inicioData && fimData ? mesesEntre(inicioData, fimData) : mesesEntre(minData, maxData);
-
-  let html = `<table class="tabela"><thead><tr><th>Categoria</th><th>Total Gasto</th><th>Custo Médio por Mês</th></tr></thead><tbody>`;
+  let html = `<table class="tabela"><thead><tr><th>Categoria</th><th>Quantidade comprada</th><th>Valor total gasto</th></tr></thead><tbody>`;
   categorias.sort().forEach(cat => {
-    const total = totais[cat];
-    const medio = total / (meses || 1);
-    html += `<tr><td>${cat}</td><td>R$ ${total.toFixed(2)}</td><td>R$ ${medio.toFixed(2)}</td></tr>`;
+    const info = totais[cat];
+    html += `<tr><td>${cat}</td><td>${info.quantidade.toLocaleString('pt-BR')} unidades</td><td>R$ ${info.valor.toFixed(2)}</td></tr>`;
   });
   html += '</tbody></table>';
   cont.innerHTML = html;

--- a/js/relatorios/financeiroOperacoes.js
+++ b/js/relatorios/financeiroOperacoes.js
@@ -1,6 +1,6 @@
 import { carregarDadosEntradas } from './entradasDados.js';
 import { carregarDadosConsumo } from './consumoDados.js';
-import { parseDataLocal } from '../utils.js';
+import { parseDataLocal, normalizarTexto } from '../utils.js';
 
 let entradas = [];
 let saidas = [];
@@ -12,12 +12,14 @@ export async function carregarOperacoes() {
 }
 
 function filtrar(lista, inicio, fim, categoria, fornecedor) {
+  const catNorm = normalizarTexto(categoria);
+  const fornNorm = normalizarTexto(fornecedor);
   return lista.filter(item => {
     const data = item.data;
     if (inicio && data && data < inicio) return false;
     if (fim && data && data > fim) return false;
-    if (categoria && item.categoria !== categoria) return false;
-    if (fornecedor && item.fornecedor !== fornecedor) return false;
+    if (categoria && normalizarTexto(item.categoria) !== catNorm) return false;
+    if (fornecedor && normalizarTexto(item.fornecedor) !== fornNorm) return false;
     return true;
   });
 }

--- a/js/relatorios/financeiroProjecao.js
+++ b/js/relatorios/financeiroProjecao.js
@@ -67,10 +67,10 @@ function gerarGrafico(projecoes) {
   });
 }
 
-async function atualizarProjecao() {
+export async function atualizarProjecao(dadosExternos = null) {
   try {
     mostrarSpinner();
-    const dados = await carregarDadosFinanceiro();
+    const dados = dadosExternos || await carregarDadosFinanceiro();
     const mapa = {};
     dados.forEach(d => {
       const parcelas = Array.isArray(d.parcelas) && d.parcelas.length > 0

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -4,6 +4,7 @@ import { normalizarTexto, parseDataLocal, formatarCompraIdCurto, formatarDataISO
 import { atualizarCardsFinanceiro } from './financeiroTotais.js';
 import { gerarTabelaFinanceiroCategorias } from './financeiroCategorias.js';
 import { atualizarOperacoesPeriodo } from './financeiroOperacoes.js';
+import { atualizarProjecao } from './financeiroProjecao.js';
 
 let dados = [];
 let filtrosIniciados = false;
@@ -86,6 +87,7 @@ export function dadosFiltradosFinanceiro() {
   const compraFiltro = document.getElementById('fin-compra-id').value.trim();
   const statusFiltro = document.getElementById('fin-status').value;
   const catProdFiltro = document.getElementById('fin-categoria-prod').value;
+  const catProdNorm = normalizarTexto(catProdFiltro);
   const inicio = document.getElementById('fin-data-inicio').value;
   const fim = document.getElementById('fin-data-fim').value;
   const inicioData = inicio ? parseDataLocal(inicio) : null;
@@ -106,7 +108,7 @@ export function dadosFiltradosFinanceiro() {
         statusMatch = d.statusParcelas === statusFiltro;
       }
     }
-    const catProdMatch = catProdFiltro === '' || (Array.isArray(d.categoriasProdutos) && d.categoriasProdutos.includes(catProdFiltro));
+    const catProdMatch = catProdNorm === '' || (Array.isArray(d.categoriasProdutos) && d.categoriasProdutos.some(c => normalizarTexto(c) === catProdNorm));
 
     let vencMatch = true;
     if (inicioData || fimData) {
@@ -135,7 +137,7 @@ export function gerarFiltrosFinanceiro() {
   const formas = new Set();
   const compras = new Set();
   const statusParcelas = new Set();
-  const categoriasProd = new Set();
+  const categoriasProdMap = new Map();
 
   const selFornecedor = document.getElementById('fin-fornecedor').value;
   const selForma = document.getElementById('fin-forma').value;
@@ -147,7 +149,12 @@ export function gerarFiltrosFinanceiro() {
     if (d.formaPagamento) formas.add(d.formaPagamento);
     if (d.compraId) compras.add(d.compraId);
     if (d.statusParcelas) statusParcelas.add(d.statusParcelas);
-    if (Array.isArray(d.categoriasProdutos)) d.categoriasProdutos.forEach(c => categoriasProd.add(c));
+    if (Array.isArray(d.categoriasProdutos)) {
+      d.categoriasProdutos.forEach(c => {
+        const norm = normalizarTexto(c);
+        if (!categoriasProdMap.has(norm)) categoriasProdMap.set(norm, c);
+      });
+    }
   });
 
   // Garante que todos os status principais estejam disponíveis no filtro
@@ -166,8 +173,8 @@ export function gerarFiltrosFinanceiro() {
     [...statusParcelas].sort().map(s => `<option value="${s}">${s}</option>`).join('');
 
   document.getElementById('fin-categoria-prod').innerHTML =
-    `<option value="">Categoria prod.</option>` +
-    [...categoriasProd].sort().map(c => {
+    `<option value="">Categoria</option>` +
+    [...categoriasProdMap.values()].sort((a,b) => a.localeCompare(b)).map(c => {
       const t = c.length > 20 ? c.slice(0,17) + "..." : c;
       return `<option value="${c}" title="${c}">${t}</option>`;
     }).join("");
@@ -196,11 +203,18 @@ export function gerarTabelaFinanceiro() {
   const lista = document.getElementById("tabela-financeiro");
 
   const filtrados = dadosFiltradosFinanceiro();
+  const catFiltroNorm = normalizarTexto(document.getElementById('fin-categoria-prod').value);
 
   if (filtrados.length === 0) {
-    lista.innerHTML = "<p>❌ Nenhum dado encontrado.</p>";
+    const msg = catFiltroNorm
+      ? 'Nenhum gasto encontrado nesta categoria no período selecionado.'
+      : '❌ Nenhum dado encontrado.';
+    lista.innerHTML = `<p>${msg}</p>`;
     atualizarCardsFinanceiro([]);
+    gerarTabelaFinanceiroCategorias([]);
     atualizarDescricaoFiltrosFinanceiro();
+    atualizarOperacoesPeriodo();
+    atualizarProjecao([]);
     return;
   }
 
@@ -255,4 +269,5 @@ export function gerarTabelaFinanceiro() {
   gerarTabelaFinanceiroCategorias(filtrados);
   atualizarDescricaoFiltrosFinanceiro();
   atualizarOperacoesPeriodo();
+  atualizarProjecao(filtrados);
 }


### PR DESCRIPTION
## Summary
- rename categoria filter label
- include categoria in entrada data and normalize comparisons
- show gastos por categoria with quantities
- export projections function and refresh with filters
- update financial table filters and messages

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6865e8b51bdc832b9acb182eaaa9fe45