### PR TITLE
Fix Brazilian format for dates and prices

### DIFF
--- a/js/estoque/estoqueUnificado.js
+++ b/js/estoque/estoqueUnificado.js
@@ -3,7 +3,7 @@
 
 import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
-import { normalizarTexto, parseDataLocal } from '../utils.js';
+import { normalizarTexto, parseDataLocal, formatarPreco, formatarDataBrasileira } from '../utils.js';
 
 // Dados carregados do Firestore
 let dadosOriginais = [];
@@ -194,10 +194,10 @@ function renderizarTabela() {
       <td>${d.quantidadeMinima}</td>
       <td>${d.entradas}</td>
       <td>${d.saidas}</td>
-      <td>${d.preco.toFixed(2)}</td>
+      <td>${formatarPreco(d.preco)}</td>
       <td>${d.consumoMedio.toFixed(1)}</td>
       <td>${dias}</td>
-      <td>${d.validade}</td>
+      <td>${formatarDataBrasileira(d.validade)}</td>
       <td>${d.categoria}</td>
       <td class="fornecedor-cell" title="${fornEsc}">${fornCurto}</td>
     </tr>`;
@@ -215,8 +215,8 @@ function atualizarCards() {
 
   document.getElementById('card-produtos').textContent = totalProdutos;
   document.getElementById('card-unidades').textContent = totalUnidades;
-  document.getElementById('card-valor-medio').textContent = valorMedio.toFixed(2);
-  document.getElementById('card-valor-total').textContent = totalValor.toFixed(2);
+  document.getElementById('card-valor-medio').textContent = formatarPreco(valorMedio);
+  document.getElementById('card-valor-total').textContent = formatarPreco(totalValor);
 }
 
 function gerarGraficos() {

--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -13,7 +13,7 @@ import {
   Timestamp
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
-import { mostrarErro, normalizarTexto, parseDataLocal, formatarCompraIdBR } from './utils.js';
+import { mostrarErro, normalizarTexto, parseDataLocal, formatarCompraIdBR, formatarPreco } from './utils.js';
 import { registrarHistorico } from './historico.js';
 
 let produtoCadastroAtual = null;
@@ -176,7 +176,7 @@ function exibirParcelas(parcelas) {
   parcelas.forEach((p, index) => {
     html += `<tr>
       <td style="text-align:center;">${p.numero}</td>
-      <td style="text-align:center;">${(p.valor || 0).toFixed(2)}</td>
+      <td style="text-align:center;">${formatarPreco(p.valor || 0)}</td>
       <td style="text-align:center;"><input type="date" id="parcela-venc-${index}" value="${p.vencimento}" /></td>
     </tr>`;
   });
@@ -247,8 +247,8 @@ window.confirmarEntradaEstoque = async function () {
     const media = await calcularPrecoMedioEntradas(produtoCadastroAtual.id);
     if (media && precoUnitario > media * 5) {
       const continuar = confirm(
-        `⚠️ O preço informado (R$ ${precoUnitario.toFixed(2)}) ` +
-        `está acima da média anterior de R$ ${media.toFixed(2)}. ` +
+        `⚠️ O preço informado (${formatarPreco(precoUnitario)}) ` +
+        `está acima da média anterior de ${formatarPreco(media)}. ` +
         'Deseja continuar mesmo assim?'
       );
       if (!continuar) {
@@ -414,7 +414,7 @@ function atualizarParcelasPreview() {
   parcelas.forEach((p, index) => {
     html += `<tr>
       <td style="text-align:center;">${p.numero}</td>
-      <td style="text-align:center;">${p.valor.toFixed(2)}</td>
+      <td style="text-align:center;">${formatarPreco(p.valor)}</td>
       <td style="text-align:center;">
         <input type="date" id="parcela-venc-${index}" value="${p.vencimento}" />
       </td>

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -12,7 +12,8 @@ import {
   calcularDiasParaVencimento,
   mostrarSpinner,
   esconderSpinner,
-  parseDataLocal
+  parseDataLocal,
+  formatarPreco
 } from './utils.js';
 import { registrarHistorico } from './historico.js';
 
@@ -532,8 +533,8 @@ function renderizarTabela(movimentacoes, termo = "") {
       <td>${m.nomeProduto}</td>
       <td>${m.tipo}</td>
       <td>${m.quantidade}</td>
-      <td>R$ ${m.precoUnitario?.toFixed(2) || "-"}</td>
-      <td>R$ ${(m.custoTotal || 0).toFixed(2)}</td>
+      <td>${m.precoUnitario != null ? formatarPreco(m.precoUnitario) : "-"}</td>
+      <td>${formatarPreco(m.custoTotal || 0)}</td>
       <td>${dataMov}</td>
       <td>${m.validade?.toDate()?.toLocaleDateString("pt-BR") || "-"}</td>
       <td>${m.lote || "-"}</td>

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -32,7 +32,8 @@ import {
   calcularDiasParaVencimento,
   executarComSpinner,
   parseDataLocal,
-  distanciaLevenshtein
+  distanciaLevenshtein,
+  formatarPreco
 } from './utils.js';
 
 // 🔧 Formatador de datas
@@ -233,15 +234,15 @@ function renderizarTabela(produtos, termo = "") {
 
     const preco =
       p.precoCompra !== undefined && p.precoCompra !== null
-        ? `R$ ${(Number(p.precoCompra) || 0).toFixed(2)}`
+        ? formatarPreco(Number(p.precoCompra) || 0)
         : "-";
     const metrica = metricasPrecoPorNome[nomeRef] || {};
     const precoMin =
-      metrica.min !== undefined ? `R$ ${metrica.min.toFixed(2)}` : "-";
+      metrica.min !== undefined ? formatarPreco(metrica.min) : "-";
     const precoMax =
-      metrica.max !== undefined ? `R$ ${metrica.max.toFixed(2)}` : "-";
+      metrica.max !== undefined ? formatarPreco(metrica.max) : "-";
     const precoMed =
-      metrica.media !== undefined ? `R$ ${metrica.media.toFixed(2)}` : "-";
+      metrica.media !== undefined ? formatarPreco(metrica.media) : "-";
 
     html += `
       <tr ${style}>
@@ -746,7 +747,7 @@ window.verDetalhes = async function(id) {
     document.getElementById('det-quantidade').textContent = p.quantidade ?? '-';
     document.getElementById('det-preco').textContent =
       p.precoCompra !== undefined && p.precoCompra !== null
-        ? `R$ ${(Number(p.precoCompra) || 0).toFixed(2)}`
+        ? formatarPreco(Number(p.precoCompra) || 0)
         : '-';
     document.getElementById('det-fornecedor').textContent = p.fornecedor || '-';
     document.getElementById('det-validade').textContent = formatarData(p.validade);

--- a/js/relatorios/entradasExportar.js
+++ b/js/relatorios/entradasExportar.js
@@ -1,3 +1,5 @@
+import { formatarPreco } from '../utils.js';
+
 export async function exportarEntradasExcel(dados) {
   const { utils, writeFile } = await import('https://cdn.sheetjs.com/xlsx-latest/package/xlsx.mjs');
 
@@ -45,7 +47,7 @@ export async function exportarEntradasPDF(dados) {
     d.nome,
     d.quantidade,
     d.validade ? d.validade.toLocaleDateString('pt-BR') : '-',
-    d.preco.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }),
+    formatarPreco(d.preco),
     d.fornecedor,
     d.compraId,
     d.data ? d.data.toLocaleDateString('pt-BR') : '-'

--- a/js/relatorios/entradasTabela.js
+++ b/js/relatorios/entradasTabela.js
@@ -1,4 +1,4 @@
-import { normalizarTexto, parseDataLocal, formatarCompraIdCurto } from '../utils.js';
+import { normalizarTexto, parseDataLocal, formatarCompraIdCurto, formatarPreco } from '../utils.js';
 import { atualizarCardsEntradas } from './entradasTotais.js';
 import { gerarGraficoEntradas } from './entradasGraficos.js';
 
@@ -130,7 +130,7 @@ function aplicarFiltros() {
         <td>${d.nome}</td>
         <td>${d.quantidade}</td>
         <td>${validade}</td>
-        <td>${d.preco.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
+        <td>${formatarPreco(d.preco)}</td>
         <td class="fornecedor-cell" title="${fornEsc}">${fornCurto}</td>
         ${mostrarCompraId ? `<td class="compra-id-cell" title="${compraEsc}">${formatarCompraIdCurto(d.compraId)}</td>` : ''}
         <td>${data}</td>

--- a/js/relatorios/entradasTotais.js
+++ b/js/relatorios/entradasTotais.js
@@ -1,13 +1,15 @@
+import { formatarPreco } from '../utils.js';
+
 export function atualizarCardsEntradas(dados) {
   const totalQuantidade = dados.reduce((acc, cur) => acc + (cur.quantidade || 0), 0);
   const totalValor = dados.reduce((acc, cur) => acc + (cur.quantidade || 0) * (cur.preco || 0), 0);
   const custoMedio = totalQuantidade ? totalValor / totalQuantidade : 0;
 
   document.getElementById('card-entradas-quantidade').textContent = totalQuantidade.toLocaleString('pt-BR');
-  document.getElementById('card-entradas-valor').textContent = totalValor.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  document.getElementById('card-entradas-valor').textContent = formatarPreco(totalValor);
 
   const custoEl = document.getElementById('card-entradas-custo');
   if (custoEl) {
-    custoEl.textContent = custoMedio.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+    custoEl.textContent = formatarPreco(custoMedio);
   }
 }

--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -5,7 +5,7 @@ import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro, dado
 import { carregarEntradasFinanceiro } from './financeiroCategorias.js';
 import { carregarOperacoes } from './financeiroOperacoes.js';
 import { exportarFinanceiroCSV, exportarFinanceiroExcel, exportarFinanceiroPDF } from './financeiroExportar.js';
-import { mostrarSpinner, esconderSpinner, mostrarMensagem, parseDataBR, formatarCompraIdCurto } from '../utils.js';
+import { mostrarSpinner, esconderSpinner, mostrarMensagem, parseDataBR, formatarCompraIdCurto, formatarPreco } from '../utils.js';
 import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where, doc, updateDoc } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
@@ -146,7 +146,7 @@ window.abrirModalParcelas = async function (compraId) {
       const btn = pago
         ? `<button onclick="marcarParcelaComoNaoPaga('${compraId}', ${p.numero})">Marcar como não pago</button>`
         : `<button onclick="marcarParcelaComoPaga('${compraId}', ${p.numero})">Marcar como pago</button>`;
-      htmlParcelas += `<tr><td>${p.numero}/${total}</td><td>R$ ${(p.valor || 0).toFixed(2)}</td><td>${venc}</td><td>${statusTexto}</td><td>${btn}</td></tr>`;
+      htmlParcelas += `<tr><td>${p.numero}/${total}</td><td>${formatarPreco(p.valor || 0)}</td><td>${venc}</td><td>${statusTexto}</td><td>${btn}</td></tr>`;
     });
     htmlParcelas += '</tbody></table>';
   }
@@ -178,7 +178,7 @@ window.abrirModalParcelas = async function (compraId) {
       htmlProdutos += '<h4>Produtos</h4><table class="tabela"><thead><tr><th>Produto</th><th>Quantidade</th><th>Preço unitário</th><th>Total</th></tr></thead><tbody>';
       Object.values(agrupados).forEach(p => {
         const total = p.quantidade * p.preco;
-        htmlProdutos += `<tr><td>${p.nome}</td><td>${p.quantidade}</td><td>R$ ${p.preco.toFixed(2)}</td><td>R$ ${total.toFixed(2)}</td></tr>`;
+        htmlProdutos += `<tr><td>${p.nome}</td><td>${p.quantidade}</td><td>${formatarPreco(p.preco)}</td><td>${formatarPreco(total)}</td></tr>`;
       });
       htmlProdutos += '</tbody></table>';
     }

--- a/js/relatorios/financeiroCategorias.js
+++ b/js/relatorios/financeiroCategorias.js
@@ -2,7 +2,7 @@
 
 import { db, getEmpresaIdDoUsuario } from '../firebaseConfig.js';
 import { collection, getDocs, query, where } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
-import { parseDataLocal } from '../utils.js';
+import { parseDataLocal, formatarPreco } from '../utils.js';
 
 let entradas = [];
 
@@ -68,7 +68,7 @@ export function gerarTabelaFinanceiroCategorias(finDados) {
   let html = `<table class="tabela"><thead><tr><th>Categoria</th><th>Quantidade comprada</th><th>Valor total gasto</th></tr></thead><tbody>`;
   categorias.sort().forEach(cat => {
     const info = totais[cat];
-    html += `<tr><td>${cat}</td><td>${info.quantidade.toLocaleString('pt-BR')} unidades</td><td>R$ ${info.valor.toFixed(2)}</td></tr>`;
+    html += `<tr><td>${cat}</td><td>${info.quantidade.toLocaleString('pt-BR')} unidades</td><td>${formatarPreco(info.valor)}</td></tr>`;
   });
   html += '</tbody></table>';
   cont.innerHTML = html;

--- a/js/relatorios/financeiroExportar.js
+++ b/js/relatorios/financeiroExportar.js
@@ -1,5 +1,7 @@
 // financeiroExportar.js
 
+import { formatarPreco } from '../utils.js';
+
 function nomeRelatorio(ext) {
   const d = new Date();
   const pad = n => String(n).padStart(2, '0');
@@ -85,10 +87,10 @@ export async function exportarFinanceiroPDF(dados) {
   }
 
   const totais = calcularTotaisFinanceiro(dados);
-  doc.text(`Total comprado: R$ ${totais.totalComprado.toFixed(2)}`, 14, 30);
-  doc.text(`Total pago: R$ ${totais.totalPago.toFixed(2)}`, 14, 36);
-  doc.text(`Total pendente: R$ ${totais.totalPendente.toFixed(2)}`, 14, 42);
-  doc.text(`Total vencido: R$ ${totais.totalVencido.toFixed(2)}`, 14, 48);
+  doc.text(`Total comprado: ${formatarPreco(totais.totalComprado)}`, 14, 30);
+  doc.text(`Total pago: ${formatarPreco(totais.totalPago)}`, 14, 36);
+  doc.text(`Total pendente: ${formatarPreco(totais.totalPendente)}`, 14, 42);
+  doc.text(`Total vencido: ${formatarPreco(totais.totalVencido)}`, 14, 48);
 
   const linhas = [];
   dados.forEach(d => {
@@ -97,7 +99,7 @@ export async function exportarFinanceiroPDF(dados) {
       d.fornecedorOuCliente,
       d.dataLancamento ? d.dataLancamento.toLocaleDateString('pt-BR') : '-',
       d.formaPagamento,
-      (d.valor || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+      formatarPreco(d.valor || 0)
     ];
     const parcelas = Array.isArray(d.parcelas) && d.parcelas.length > 0
       ? d.parcelas
@@ -106,7 +108,7 @@ export async function exportarFinanceiroPDF(dados) {
       linhas.push([
         ...base,
         p.numero,
-        (p.valor || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }),
+        formatarPreco(p.valor || 0),
         p.vencimento ? new Date(p.vencimento).toLocaleDateString('pt-BR') : '-',
         p.status,
         p.dataPagamento ? new Date(p.dataPagamento).toLocaleDateString('pt-BR') : '-'

--- a/js/relatorios/financeiroOperacoes.js
+++ b/js/relatorios/financeiroOperacoes.js
@@ -1,6 +1,6 @@
 import { carregarDadosEntradas } from './entradasDados.js';
 import { carregarDadosConsumo } from './consumoDados.js';
-import { parseDataLocal, normalizarTexto } from '../utils.js';
+import { parseDataLocal, normalizarTexto, formatarPreco } from '../utils.js';
 
 let entradas = [];
 let saidas = [];
@@ -99,8 +99,8 @@ export function atualizarOperacoesPeriodo() {
 
   document.getElementById('valor-produtos-comprados').textContent = prodComprados.toLocaleString('pt-BR');
   document.getElementById('valor-produtos-consumidos').textContent = prodConsumidos.toLocaleString('pt-BR');
-  document.getElementById('valor-gasto-compras').textContent = valorCompras.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-  document.getElementById('valor-total-saidas').textContent = valorSaidas.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  document.getElementById('valor-gasto-compras').textContent = formatarPreco(valorCompras);
+  document.getElementById('valor-total-saidas').textContent = formatarPreco(valorSaidas);
 
   gerarGrafico(entradasFiltradas, saidasFiltradas);
 }

--- a/js/relatorios/financeiroProjecao.js
+++ b/js/relatorios/financeiroProjecao.js
@@ -1,6 +1,6 @@
 // financeiroProjecao.js — Projeção de pagamentos futuros
 import { carregarDadosFinanceiro } from './financeiroDados.js';
-import { mostrarSpinner, esconderSpinner } from '../utils.js';
+import { mostrarSpinner, esconderSpinner, formatarPreco } from '../utils.js';
 
 let grafico = null;
 
@@ -21,7 +21,7 @@ function gerarTabela(projecoes) {
 
   let html = `<table class="tabela"><thead><tr><th>Mês</th><th>Valor Total Previsto</th></tr></thead><tbody>`;
   projecoes.forEach(p => {
-    html += `<tr><td>${formatarMes(p.mes)}</td><td>R$ ${p.valor.toFixed(2)}</td></tr>`;
+    html += `<tr><td>${formatarMes(p.mes)}</td><td>${formatarPreco(p.valor)}</td></tr>`;
   });
   html += '</tbody></table>';
   cont.innerHTML = html;

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -1,6 +1,6 @@
 // financeiroTabela.js — Geração de tabela e filtros
 
-import { normalizarTexto, parseDataLocal, formatarCompraIdCurto, formatarDataISOParaBR } from '../utils.js';
+import { normalizarTexto, parseDataLocal, formatarCompraIdCurto, formatarDataISOParaBR, formatarPreco } from '../utils.js';
 import { atualizarCardsFinanceiro } from './financeiroTotais.js';
 import { gerarTabelaFinanceiroCategorias } from './financeiroCategorias.js';
 import { atualizarOperacoesPeriodo } from './financeiroOperacoes.js';
@@ -251,9 +251,9 @@ export function gerarTabelaFinanceiro() {
         <td class="fornecedor-cell" title="${fornecedorEscapado}">${fornecedorCurto}</td>
         <td>${lanc}</td>
         <td>${d.formaPagamento}</td>
-        <td>R$ ${(d.valor).toFixed(2)}</td>
-        <td>R$ ${pago.toFixed(2)}</td>
-        <td class="valor-aberto">R$ ${aberto.toFixed(2)}</td>
+        <td>${formatarPreco(d.valor)}</td>
+        <td>${formatarPreco(pago)}</td>
+        <td class="valor-aberto">${formatarPreco(aberto)}</td>
         <td>
           ${formatarResumoParcelas(d.parcelas)}<br>
           <button onclick="abrirModalParcelas('${d.compraId}')">Detalhes</button>

--- a/js/relatorios/financeiroTotais.js
+++ b/js/relatorios/financeiroTotais.js
@@ -1,4 +1,5 @@
 // financeiroTotais.js — Cálculo e atualização dos cards
+import { formatarPreco } from '../utils.js';
 
 export function calcularTotaisFinanceiro(dados) {
   let totalComprado = 0;
@@ -36,8 +37,8 @@ export function calcularTotaisFinanceiro(dados) {
 export function atualizarCardsFinanceiro(dados) {
   const totais = calcularTotaisFinanceiro(dados);
 
-  document.getElementById('total-comprado').textContent = `R$ ${totais.totalComprado.toFixed(2)}`;
-  document.getElementById('total-pago').textContent = `R$ ${totais.totalPago.toFixed(2)}`;
-  document.getElementById('total-pendente').textContent = `R$ ${totais.totalPendente.toFixed(2)}`;
-  document.getElementById('total-vencido').textContent = `R$ ${totais.totalVencido.toFixed(2)}`;
+  document.getElementById('total-comprado').textContent = formatarPreco(totais.totalComprado);
+  document.getElementById('total-pago').textContent = formatarPreco(totais.totalPago);
+  document.getElementById('total-pendente').textContent = formatarPreco(totais.totalPendente);
+  document.getElementById('total-vencido').textContent = formatarPreco(totais.totalVencido);
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -176,3 +176,16 @@ export function formatarCompraIdBR(id) {
   const numero = String(Number(numeroRaw));
   return `Compra ${numero} - ${dia}/${mes}/${ano}`;
 }
+
+// 👉 Formatar valores monetários no padrão brasileiro (R$ 12,34)
+export function formatarPreco(valor) {
+  const num = Number(valor) || 0;
+  return `R$ ${num.toFixed(2).replace('.', ',')}`;
+}
+
+// 👉 Formatar datas em DD/MM/AAAA
+export function formatarDataBrasileira(data) {
+  const d = data?.toDate ? data.toDate() : new Date(data);
+  if (isNaN(d)) return '';
+  return d.toLocaleDateString('pt-BR');
+}


### PR DESCRIPTION
## Summary
- add helpers `formatarPreco` and `formatarDataBrasileira`
- use the helpers across reports, tables, and modals
- ensure estoque unified report shows valid date format
- update financial exports and totals to show values as `R$ 0,00`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865eac4ff00832bbd4787158d45e4ef