### PR TITLE
Fix category filter in finance page

### DIFF
--- a/js/relatorios/financeiroCategorias.js
+++ b/js/relatorios/financeiroCategorias.js
@@ -28,6 +28,14 @@ export async function carregarEntradasFinanceiro() {
   return entradas;
 }
 
+export function obterCategoriasEntradas() {
+  return Array.from(new Set(
+    entradas
+      .map(e => e.categoria)
+      .filter(c => c && c !== '-')
+  ));
+}
+
 export function gerarTabelaFinanceiroCategorias(finDados) {
   const cont = document.getElementById('tabela-fin-categorias');
   if (!cont) return;

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -2,7 +2,7 @@
 
 import { normalizarTexto, parseDataLocal, formatarCompraIdCurto, formatarDataISOParaBR, formatarPreco } from '../utils.js';
 import { atualizarCardsFinanceiro } from './financeiroTotais.js';
-import { gerarTabelaFinanceiroCategorias } from './financeiroCategorias.js';
+import { gerarTabelaFinanceiroCategorias, obterCategoriasEntradas } from './financeiroCategorias.js';
 import { atualizarOperacoesPeriodo } from './financeiroOperacoes.js';
 import { atualizarProjecao } from './financeiroProjecao.js';
 
@@ -138,6 +138,7 @@ export function gerarFiltrosFinanceiro() {
   const compras = new Set();
   const statusParcelas = new Set();
   const categoriasProdMap = new Map();
+  const categoriasEntradas = obterCategoriasEntradas();
 
   const selFornecedor = document.getElementById('fin-fornecedor').value;
   const selForma = document.getElementById('fin-forma').value;
@@ -155,6 +156,11 @@ export function gerarFiltrosFinanceiro() {
         if (!categoriasProdMap.has(norm)) categoriasProdMap.set(norm, c);
       });
     }
+  });
+
+  categoriasEntradas.forEach(c => {
+    const norm = normalizarTexto(c);
+    if (!categoriasProdMap.has(norm)) categoriasProdMap.set(norm, c);
   });
 
   // Garante que todos os status principais estejam disponíveis no filtro


### PR DESCRIPTION
## Summary
- export a function to retrieve categories from purchase entries
- use categories from entries when building finance filters

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865f082cbf8832bba422c0ce85e3b73