### PR TITLE
Atualiza visual e cálculo de operações financeiras

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -27,43 +27,6 @@
 
   <main class="main-content">
     <h1>💰 Financeiro</h1>
-    <div id="alerta-vencidas" class="alert-aviso" style="display:none; margin-bottom:10px;"></div>
-
-    <section id="operacoes-periodo" style="margin-bottom:20px;">
-      <h2>Operações financeiras por período</h2>
-      <div id="cards-operacoes-periodo" class="cards">
-        <div class="resumo-card" id="card-produtos-comprados">
-          <div class="icone">📥</div>
-          <div class="texto">
-            <div class="titulo text-sm text-gray-500">Produtos comprados</div>
-            <div class="valor text-xl font-semibold" id="valor-produtos-comprados">-</div>
-          </div>
-        </div>
-        <div class="resumo-card" id="card-produtos-consumidos">
-          <div class="icone">📦</div>
-          <div class="texto">
-            <div class="titulo text-sm text-gray-500">Produtos consumidos</div>
-            <div class="valor text-xl font-semibold" id="valor-produtos-consumidos">-</div>
-          </div>
-        </div>
-        <div class="resumo-card" id="card-valor-compras">
-          <div class="icone">💰</div>
-          <div class="texto">
-            <div class="titulo text-sm text-gray-500">Valor total gasto</div>
-            <div class="valor text-xl font-semibold" id="valor-gasto-compras">-</div>
-          </div>
-        </div>
-        <div class="resumo-card" id="card-valor-saidas-periodo">
-          <div class="icone">💸</div>
-          <div class="texto">
-            <div class="titulo text-sm text-gray-500">Valor total em saídas</div>
-            <div class="valor text-xl font-semibold" id="valor-total-saidas">-</div>
-          </div>
-        </div>
-      </div>
-      <canvas id="grafico-operacoes" style="max-height:300px; margin-top:10px;"></canvas>
-    </section>
-
     <div class="filtros filtros-financeiro">
       <div class="campo-filtro estreito">
         <label for="fin-data-inicio">De</label>
@@ -104,8 +67,31 @@
         <button id="botao-exportar-pdf-fin" class="botao-acao" title="Exportar PDF">🖨️</button>
       </div>
     </div>
-
     <p id="descricao-filtros-fin" class="descricao-filtros"></p>
+    <div id="alerta-vencidas" class="alert-aviso" style="display:none; margin-bottom:10px;"></div>
+
+    <section id="operacoes-periodo" style="margin-bottom:20px;">
+      <h2>Gastos com entradas e saídas</h2>
+      <div id="cards-operacoes-periodo" class="cards">
+        <div class="resumo-card" id="card-valor-compras">
+          <div class="icone">💰</div>
+          <div class="texto">
+            <div class="titulo text-sm text-gray-500">Valor total gasto em novas entradas</div>
+            <div class="valor text-xl font-semibold" id="valor-gasto-compras">-</div>
+          </div>
+        </div>
+        <div class="resumo-card" id="card-valor-saidas-periodo">
+          <div class="icone">💸</div>
+          <div class="texto">
+            <div class="titulo text-sm text-gray-500">Valor total gasto em saída de produtos</div>
+            <div class="valor text-xl font-semibold" id="valor-total-saidas">-</div>
+          </div>
+        </div>
+      </div>
+      <h3 style="margin-top:10px;">Valores mensais de entradas e saídas (R$)</h3>
+      <canvas id="grafico-operacoes" style="max-height:300px; margin-top:10px;"></canvas>
+    </section>
+
 
     <div id="cards-financeiro" class="cards">
       <div class="resumo-card" id="card-total-comprado">

--- a/js/relatorios/financeiroOperacoes.js
+++ b/js/relatorios/financeiroOperacoes.js
@@ -44,8 +44,16 @@ function gerarGrafico(entradasFiltradas, saidasFiltradas) {
   });
   const meses = Array.from(mesesSet).sort();
 
-  const dadosEntradas = meses.map(m => entradasFiltradas.filter(e => e.data && `${e.data.getFullYear()}-${String(e.data.getMonth()+1).padStart(2,'0')}` === m).reduce((a,c) => a + (c.quantidade || 0), 0));
-  const dadosSaidas = meses.map(m => saidasFiltradas.filter(s => s.data && `${s.data.getFullYear()}-${String(s.data.getMonth()+1).padStart(2,'0')}` === m).reduce((a,c) => a + (c.quantidade || 0), 0));
+  const dadosEntradas = meses.map(m =>
+    entradasFiltradas
+      .filter(e => e.data && `${e.data.getFullYear()}-${String(e.data.getMonth() + 1).padStart(2, '0')}` === m)
+      .reduce((a, c) => a + (c.quantidade || 0) * (c.preco || 0), 0)
+  );
+  const dadosSaidas = meses.map(m =>
+    saidasFiltradas
+      .filter(s => s.data && `${s.data.getFullYear()}-${String(s.data.getMonth() + 1).padStart(2, '0')}` === m)
+      .reduce((a, c) => a + (c.custoTotal || (c.quantidade || 0) * (c.precoUnitario || 0)), 0)
+  );
 
   grafico = new Chart(ctx, {
     type: 'line',
@@ -92,13 +100,9 @@ export function atualizarOperacoesPeriodo() {
   const entradasFiltradas = filtrar(entradas, inicio, fim, categoria, fornecedor);
   const saidasFiltradas = filtrar(saidas, inicio, fim, categoria, fornecedor);
 
-  const prodComprados = entradasFiltradas.reduce((s,e) => s + (e.quantidade || 0), 0);
   const valorCompras = entradasFiltradas.reduce((s,e) => s + (e.quantidade || 0)*(e.preco || 0), 0);
-  const prodConsumidos = saidasFiltradas.reduce((s,sai) => s + (sai.quantidade || 0), 0);
   const valorSaidas = saidasFiltradas.reduce((s,sai) => s + (sai.custoTotal || (sai.quantidade || 0)*(sai.precoUnitario || 0)), 0);
 
-  document.getElementById('valor-produtos-comprados').textContent = prodComprados.toLocaleString('pt-BR');
-  document.getElementById('valor-produtos-consumidos').textContent = prodConsumidos.toLocaleString('pt-BR');
   document.getElementById('valor-gasto-compras').textContent = formatarPreco(valorCompras);
   document.getElementById('valor-total-saidas').textContent = formatarPreco(valorSaidas);
 


### PR DESCRIPTION
## Summary
- move filtros do financeiro para o topo da página
- atualizar texto do título da seção de operações financeiras
- remover cards de quantidade
- exibir valores totais de entradas e saídas
- ajustar gráfico para mostrar valores em reais

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865f226041c832b94dd1a2e6faeaa9e