### PR TITLE
Improve overdue warning usability

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -681,3 +681,18 @@ button.btn-icon.btn-xl { font-size: 16px; padding: 8px; }
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* Linhas da tabela financeira por status */
+tr.status-pago { background-color: #eafaf1; }
+tr.status-pendente { background-color: #fff8e6; }
+tr.status-vencido { background-color: #fdecea; }
+
+/* Destaque temporário de linha */
+tr.destacar {
+  animation: brilho-destacado 2s ease;
+}
+
+@keyframes brilho-destacado {
+  0% { box-shadow: 0 0 0 3px #f39c12 inset; }
+  100% { box-shadow: none; }
+}

--- a/js/relatorios/financeiro.js
+++ b/js/relatorios/financeiro.js
@@ -1,7 +1,7 @@
 // financeiro.js — Controlador geral do módulo financeiro
 
 import { carregarDadosFinanceiro } from './financeiroDados.js';
-import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro, dadosFiltradosFinanceiro } from './financeiroTabela.js';
+import { setDadosFinanceiro, gerarFiltrosFinanceiro, gerarTabelaFinanceiro, dadosFiltradosFinanceiro, rolarParaPrimeiraVencida } from './financeiroTabela.js';
 import { carregarEntradasFinanceiro } from './financeiroCategorias.js';
 import { carregarOperacoes } from './financeiroOperacoes.js';
 import { exportarFinanceiroCSV, exportarFinanceiroExcel, exportarFinanceiroPDF } from './financeiroExportar.js';
@@ -39,6 +39,7 @@ function exibirAlertaVencidas() {
       e.preventDefault();
       document.getElementById('fin-status').value = 'vencido';
       gerarTabelaFinanceiro();
+      rolarParaPrimeiraVencida();
       aviso.style.display = 'none';
     }, { once: true });
   } else {

--- a/js/relatorios/financeiroTabela.js
+++ b/js/relatorios/financeiroTabela.js
@@ -251,8 +251,9 @@ export function gerarTabelaFinanceiro() {
       ? nomeFornecedor.slice(0, 20) + '...'
       : nomeFornecedor;
     const compraEscapado = (d.compraId || '').replace(/"/g, '&quot;');
+    const classeStatus = d.statusParcelas ? `status-${d.statusParcelas}` : '';
     html += `
-      <tr>
+      <tr class="${classeStatus}">
         <td class="compra-id-cell" title="${compraEscapado}">${formatarCompraIdCurto(d.compraId)}</td>
         <td class="fornecedor-cell" title="${fornecedorEscapado}">${fornecedorCurto}</td>
         <td>${lanc}</td>
@@ -276,4 +277,16 @@ export function gerarTabelaFinanceiro() {
   atualizarDescricaoFiltrosFinanceiro();
   atualizarOperacoesPeriodo();
   atualizarProjecao(filtrados);
+}
+
+// 👉 Rolar e destacar a primeira linha vencida na tabela
+export function rolarParaPrimeiraVencida() {
+  const linha = document.querySelector('#tabela-financeiro tr.status-vencido');
+  if (linha) {
+    linha.classList.add('destacar');
+    linha.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setTimeout(() => linha.classList.remove('destacar'), 2000);
+  } else {
+    document.getElementById('tabela-financeiro')?.scrollIntoView({ behavior: 'smooth' });
+  }
 }


### PR DESCRIPTION
## Summary
- highlight finance rows according to payment status
- scroll and highlight the first overdue row when clicking alert

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `cd functions && npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f20c600832b9263696c008e1a80