### PR TITLE
Fix movimentações behavior with fornecedor and validade

### DIFF
--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -507,8 +507,11 @@ document.getElementById("form-movimentacao").addEventListener("submit", async (e
   const fornecedorMov = document.getElementById("fornecedor-mov").value.trim();
 
   if (tipo === "saida") {
-    const validadeKey = validade.toISOString().split("T")[0];
-    const disponivel = mapaValidades[validadeKey] || 0;
+    if (!validadeStr) {
+      alert("❌ Selecione a validade da saída.");
+      return;
+    }
+    const disponivel = mapaValidades[validadeStr] || 0;
 
     if (quantidade > disponivel) {
       alert(`❌ Estoque insuficiente. Só há ${disponivel} unidade(s) disponíveis para essa validade.`);
@@ -571,7 +574,7 @@ document.getElementById("form-movimentacao").addEventListener("submit", async (e
 
         const fornecedorSaida =
           (await obterFornecedorDaValidade(produto.nome, validadeStr)) ||
-          produto.fornecedor;
+          produto.fornecedor || "";
 
         await addDoc(collection(db, "empresas", empresaId, "movimentacoes"), {
           produtoId: produtoEncontrado.id,
@@ -719,7 +722,8 @@ window.editarMovimentacao = async function (id) {
       if (window.adicionarFornecedor) window.adicionarFornecedor(fornecedor);
     } else {
       fornecedor =
-        (await obterFornecedorDaValidade(nomeProduto, validadeStr)) || "";
+        (await obterFornecedorDaValidade(nomeProduto, validadeStr)) ||
+        (produtosCache.find(p => normalizarTexto(p.nome) === normalizarTexto(nomeProduto))?.fornecedor || "");
     }
 
     const atualizados = {


### PR DESCRIPTION
## Summary
- validate selected validity before allowing a saída
- keep fornecedor when deriving from validade and when editing

## Testing
- `node --check js/movimentacoes.js`

------
https://chatgpt.com/codex/tasks/task_e_686ab28f7dc4832b81d2c780e839b4f1