### PR TITLE
Highlight movimentações by type

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -686,6 +686,8 @@ button.btn-icon.btn-xl { font-size: 16px; padding: 8px; }
 tr.status-pago { background-color: #eafaf1; }
 tr.status-pendente { background-color: #fff8e6; }
 tr.status-vencido { background-color: #fdecea; }
+tr.mov-entrada { background-color: #e8f5e9; }
+tr.mov-saida { background-color: #ffebee; }
 
 /* Destaque temporário de linha */
 tr.destacar {

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -642,7 +642,8 @@ function renderizarTabela(movimentacoes, termo = "") {
 
   filtradas.forEach(m => {
     const dataMov = m.dataMovimentacao?.toDate()?.toLocaleDateString("pt-BR") || "-";
-    html += `<tr>
+    const classeTipo = m.tipo === "entrada" ? "mov-entrada" : m.tipo === "saida" ? "mov-saida" : "";
+    html += `<tr class="${classeTipo}">
       <td>${m.nomeProduto}</td>
       <td>${m.tipo}</td>
       <td>${m.quantidade}</td>


### PR DESCRIPTION
## Summary
- color rows in movimentações table according to type
- include CSS classes for entrada/saída styling

## Testing
- `npm test --silent` *(fails: no tests / network restrictions)*
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_686abfd8b2a4832ba7ea81c1c4a5a91f