### PR TITLE
Add filters to movimentacoes table

### DIFF
--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -33,6 +33,7 @@ let produtosPorNome = {}; // Novo: agrupamento por nome normalizado
 let mapaValidades = {}; // Novo: quantidades por validade
 let listenerFormulario = null; // usado ao editar uma movimentacao
 let fornecedoresSet = new Set();
+let compraIdSet = new Set();
 let fornecedorOriginalEdicao = null; // armazena fornecedor original durante edição
 
 // =========================
@@ -49,7 +50,15 @@ async function carregarMovimentacoes() {
     const snapshot = await getDocs(q);
     movimentacoesCache = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 
-    renderizarTabela(movimentacoesCache);
+    compraIdSet = new Set();
+    movimentacoesCache.forEach(m => {
+      if (m.compraId) compraIdSet.add(m.compraId);
+      if (m.fornecedor) fornecedoresSet.add(m.fornecedor.trim());
+    });
+
+    atualizarListaFornecedores();
+    atualizarDatalistsFiltros();
+    aplicarFiltros();
   } catch (error) {
     console.error("❌ Erro ao carregar movimentações:", error);
     mostrarErro("Erro ao carregar movimentações.", error);
@@ -111,16 +120,20 @@ async function carregarProdutos() {
       .map(f => `<option value="${f}">`)
       .join("");
   }
+
+  atualizarListaFornecedores();
+  atualizarDatalistsFiltros();
 }
 
 function atualizarListaFornecedores() {
   const listaFor = document.getElementById("lista-fornecedores-mov");
-  if (listaFor) {
-    listaFor.innerHTML = [...fornecedoresSet]
-      .sort()
-      .map(f => `<option value="${f}">`)
-      .join("");
-  }
+  const listaFiltro = document.getElementById("lista-fornecedores-filtro");
+  const html = [...fornecedoresSet]
+    .sort()
+    .map(f => `<option value="${f}">`)
+    .join("");
+  if (listaFor) listaFor.innerHTML = html;
+  if (listaFiltro) listaFiltro.innerHTML = html;
 }
 
 function adicionarFornecedor(fornecedor) {
@@ -144,6 +157,22 @@ async function carregarFornecedoresDasMovimentacoes(empresaId) {
     const mov = docu.data();
     if (mov.fornecedor) fornecedoresSet.add(mov.fornecedor.trim());
   });
+}
+
+function atualizarDatalistsFiltros() {
+  const listaProdutos = document.getElementById("lista-produtos-filtro");
+  if (listaProdutos) {
+    const nomes = [...new Set(produtosCache.map(p => p.nome))].sort();
+    listaProdutos.innerHTML = nomes.map(n => `<option value="${n}">`).join("");
+  }
+
+  const listaCompra = document.getElementById("lista-compra-id-filtro");
+  if (listaCompra) {
+    listaCompra.innerHTML = [...compraIdSet]
+      .sort()
+      .map(id => `<option value="${id}">`)
+      .join("");
+  }
 }
 
 carregarProdutos();
@@ -483,11 +512,55 @@ grupoValidadeSaida.style.display = "block";
 }
 
 // =========================
-// 🔥 Filtro da Tabela
+// 🔥 Filtros Dinâmicos
 // =========================
-document.getElementById("filtro-movimentacao").addEventListener("input", function () {
-  const termo = normalizarTexto(this.value.trim());
-  renderizarTabela(movimentacoesCache, termo);
+function aplicarFiltros() {
+  const tipo = document.getElementById("filtro-tipo-mov").value;
+  const nome = normalizarTexto(document.getElementById("filtro-produto-mov").value.trim());
+  const fornecedor = document.getElementById("filtro-fornecedor-mov").value.trim();
+  const compraId = document.getElementById("filtro-compra-mov").value.trim();
+  const dataInicio = document.getElementById("filtro-data-inicio-mov").value;
+  const dataFim = document.getElementById("filtro-data-fim-mov").value;
+
+  const filtradas = movimentacoesCache.filter(m => {
+    if (tipo && m.tipo !== tipo) return false;
+    if (nome && !normalizarTexto(m.nomeProduto || "").includes(nome)) return false;
+    if (fornecedor && (m.fornecedor || "") !== fornecedor) return false;
+    if (compraId && (m.compraId || "") !== compraId) return false;
+
+    let dataMov = m.dataMovimentacao?.toDate();
+    if (dataInicio && (!dataMov || dataMov < parseDataLocal(dataInicio))) return false;
+    if (dataFim && (!dataMov || dataMov > parseDataLocal(dataFim))) return false;
+    return true;
+  });
+
+  renderizarTabela(filtradas);
+  const contador = document.getElementById("contador-movimentacoes");
+  if (contador) contador.textContent = `Exibindo ${filtradas.length} movimentações`;
+}
+
+function limparFiltrosMovimentacoes() {
+  document.getElementById("filtro-tipo-mov").value = "";
+  document.getElementById("filtro-produto-mov").value = "";
+  document.getElementById("filtro-fornecedor-mov").value = "";
+  document.getElementById("filtro-compra-mov").value = "";
+  document.getElementById("filtro-data-inicio-mov").value = "";
+  document.getElementById("filtro-data-fim-mov").value = "";
+  aplicarFiltros();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  [
+    "filtro-tipo-mov",
+    "filtro-produto-mov",
+    "filtro-fornecedor-mov",
+    "filtro-compra-mov",
+    "filtro-data-inicio-mov",
+    "filtro-data-fim-mov",
+  ].forEach(id => {
+    document.getElementById(id)?.addEventListener("input", aplicarFiltros);
+  });
+  document.getElementById("botao-limpar-filtros")?.addEventListener("click", limparFiltrosMovimentacoes);
 });
 
 // =========================
@@ -611,13 +684,9 @@ document.getElementById("form-movimentacao").addEventListener("submit", async (e
 // =========================
 // 🔥 Renderizar Tabela
 // =========================
-function renderizarTabela(movimentacoes, termo = "") {
+function renderizarTabela(movimentacoes) {
   const lista = document.getElementById("lista-movimentacoes");
-
-  const filtradas = movimentacoes.filter(m => {
-    const nomeNormalizado = normalizarTexto(m.nomeProduto || "");
-    return nomeNormalizado.includes(normalizarTexto(termo));
-  });
+  const filtradas = movimentacoes;
 
   let html = `
     <table border="1" cellpadding="8">

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -100,7 +100,49 @@
 
       <!-- Lista de Movimentações -->
       <h2>Histórico de Movimentações</h2>
-      <input type="text" id="filtro-movimentacao" placeholder="🔍 Buscar por produto..." style="padding:6px; width: 250px; margin-bottom: 20px;">
+      <div class="filtros">
+        <div class="campo-filtro">
+          <label for="filtro-tipo-mov">Tipo:</label>
+          <select id="filtro-tipo-mov">
+            <option value="">Todos</option>
+            <option value="entrada">Entrada</option>
+            <option value="saida">Saída</option>
+          </select>
+        </div>
+
+        <div class="campo-filtro">
+          <label for="filtro-produto-mov">Produto:</label>
+          <input type="text" id="filtro-produto-mov" list="lista-produtos-filtro" placeholder="Produto...">
+          <datalist id="lista-produtos-filtro"></datalist>
+        </div>
+
+        <div class="campo-filtro">
+          <label for="filtro-data-inicio-mov">Data de:</label>
+          <input type="date" id="filtro-data-inicio-mov">
+        </div>
+
+        <div class="campo-filtro">
+          <label for="filtro-data-fim-mov">Data até:</label>
+          <input type="date" id="filtro-data-fim-mov">
+        </div>
+
+        <div class="campo-filtro">
+          <label for="filtro-fornecedor-mov">Fornecedor:</label>
+          <input type="text" id="filtro-fornecedor-mov" list="lista-fornecedores-filtro">
+          <datalist id="lista-fornecedores-filtro"></datalist>
+        </div>
+
+        <div class="campo-filtro">
+          <label for="filtro-compra-mov">Compra ID:</label>
+          <input type="text" id="filtro-compra-mov" list="lista-compra-id-filtro">
+          <datalist id="lista-compra-id-filtro"></datalist>
+        </div>
+
+        <div class="campo-filtro" style="display:flex;align-items:end;">
+          <button type="button" id="botao-limpar-filtros">Limpar filtros</button>
+        </div>
+      </div>
+      <p id="contador-movimentacoes"></p>
       <div id="lista-movimentacoes"></div>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- add filter controls on movimentações page
- populate lists for products, fornecedores and compra IDs
- support dynamic filtering without page reload

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d1cc42348832bbc30f219f5b7db71