### PR TITLE
Reestrutura layout do formulário de movimentações

### DIFF
--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -33,14 +33,14 @@
       <form id="form-movimentacao">
         <h2>Registrar Movimentação</h2>
 
-        <div class="form-grid">
-          <div style="position: relative;">
+        <div class="form-grid" style="grid-template-columns: repeat(6, 1fr);">
+          <div class="form-group" style="grid-column: span 2; position: relative;">
             <label>Produto:</label>
             <input type="text" id="nome-produto" placeholder="Nome do Produto" required>
             <ul id="sugestoes-produto" class="autocomplete-list"></ul>
           </div>
 
-          <div>
+          <div class="form-group">
             <label>Tipo:</label>
             <select id="tipo-movimentacao" required>
               <option value="entrada">Entrada</option>
@@ -48,51 +48,51 @@
             </select>
           </div>
 
-          <div>
+          <div class="form-group">
             <label>Quantidade:</label>
             <input type="number" id="quantidade" min="1" required>
           </div>
 
-          <div>
+          <div class="form-group">
             <label>Preço Unitário:</label>
             <input type="number" id="preco-unitario" min="0" step="0.01">
           </div>
 
-          <div>
+          <div class="form-group">
             <label>Data:</label>
             <input type="date" id="data-movimentacao" required>
           </div>
 
-          <div>
+          <div class="form-group">
             <label>Validade:</label>
             <input type="date" id="validade" required>
           </div>
 
-          <div id="grupo-fornecedor">
+          <div id="grupo-fornecedor" class="form-group" style="grid-column: span 2;">
             <label>Fornecedor:</label>
             <input list="lista-fornecedores-mov" id="fornecedor-mov" placeholder="Fornecedor" />
             <datalist id="lista-fornecedores-mov"></datalist>
           </div>
 
           <!-- Select de Validades (exibido apenas em Saída com múltiplas validades) -->
-          <div id="grupo-validade-saida" style="display: none;">
+          <div id="grupo-validade-saida" class="form-group" style="display: none;">
             <label>Escolha a Validade para Saída:</label>
             <select id="select-validade-saida">
               <option value="">-- Selecione a validade --</option>
             </select>
           </div>
 
-          <div>
+          <div class="form-group">
             <label>Lote:</label>
             <input type="text" id="lote">
           </div>
 
-          <div style="grid-column: 1 / -1">
+          <div class="form-group" style="grid-column: span 3;">
             <label>Observações:</label>
-            <textarea id="observacoes" rows="3"></textarea>
+            <textarea id="observacoes" rows="1"></textarea>
           </div>
 
-          <div style="grid-column: 1 / -1; text-align: left;">
+          <div class="form-group" style="grid-column: 1 / -1; text-align: right;">
             <button type="submit">Salvar Movimentação</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reorganize form fields in `movimentacoes.html` so they fit two lines using a six-column grid
- add column spans and align save button to the right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686effb4f460832b9adb2ba0b83ec637