### PR TITLE
Restore default field sizes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -213,11 +213,6 @@ button {
   transition: background-color 0.3s;
 }
 
-.btn-form {
-  padding: 6px 16px;
-  height: 32px;
-}
-
 button:focus {
   outline: 2px solid #00796b;
   outline-offset: 2px;
@@ -451,37 +446,11 @@ table tbody tr:hover {
 .form-grid select,
 .form-grid textarea {
   width: 100%;
-  padding: 6px 8px;
+  padding: 8px;
   font-size: 14px;
   border-radius: 6px;
   border: 1px solid #ccc;
   box-sizing: border-box;
-  height: 32px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-
-/* Tamanhos reduzidos para campos de formulários */
-.campo-xs {
-  width: 60px;
-}
-
-.campo-sm {
-  width: 90px;
-}
-
-.campo-md {
-  width: 130px;
-}
-
-.campo-lg {
-  width: 160px;
-}
-
-.campo-xl {
-  width: 220px;
 }
 
 /* 🔍 Filtros de páginas de relatório */

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -33,17 +33,16 @@
       <form id="form-movimentacao">
         <h2>Registrar Movimentação</h2>
 
-        <div class="form-grid" style="grid-template-columns: repeat(6, auto);">
-
+        <div class="form-grid" style="grid-template-columns: repeat(6, 1fr);">
           <div class="form-group" style="grid-column: span 2; position: relative;">
             <label>Produto:</label>
-            <input type="text" id="nome-produto" class="campo-lg" placeholder="Nome do Produto" required>
+            <input type="text" id="nome-produto" placeholder="Nome do Produto" required>
             <ul id="sugestoes-produto" class="autocomplete-list"></ul>
           </div>
 
           <div class="form-group" style="grid-column: span 1;">
             <label>Tipo:</label>
-            <select id="tipo-movimentacao" class="campo-xs" required>
+            <select id="tipo-movimentacao" required>
               <option value="entrada">Entrada</option>
               <option value="saida">Saída</option>
             </select>
@@ -51,26 +50,26 @@
 
           <div class="form-group" style="grid-column: span 1;">
             <label>Quantidade:</label>
-            <input type="number" id="quantidade" class="campo-xs" min="1" required>
+            <input type="number" id="quantidade" min="1" required>
           </div>
           <div class="form-group" style="grid-column: span 1;">
             <label>Preço Unitário:</label>
-            <input type="number" id="preco-unitario" class="campo-sm" min="0" step="0.01">
+            <input type="number" id="preco-unitario" min="0" step="0.01">
           </div>
 
           <div class="form-group" style="grid-column: span 1;">
             <label>Data:</label>
-            <input type="date" id="data-movimentacao" class="campo-sm" required>
+            <input type="date" id="data-movimentacao" required>
           </div>
 
           <div class="form-group" style="grid-column: span 1;">
             <label>Validade:</label>
-            <input type="date" id="validade" class="campo-sm" required>
+            <input type="date" id="validade" required>
           </div>
 
           <div id="grupo-fornecedor" class="form-group" style="grid-column: span 2;">
             <label>Fornecedor:</label>
-            <input list="lista-fornecedores-mov" id="fornecedor-mov" class="campo-lg" placeholder="Fornecedor" />
+            <input list="lista-fornecedores-mov" id="fornecedor-mov" placeholder="Fornecedor" />
             <datalist id="lista-fornecedores-mov"></datalist>
           </div>
 
@@ -84,16 +83,16 @@
 
           <div class="form-group" style="grid-column: span 1;">
             <label>Lote:</label>
-            <input type="text" id="lote" class="campo-sm">
+            <input type="text" id="lote">
           </div>
 
           <div class="form-group" style="grid-column: span 2;">
             <label>Observações:</label>
-            <textarea id="observacoes" class="campo-xl" rows="1"></textarea>
+            <textarea id="observacoes" rows="1"></textarea>
           </div>
 
           <div class="form-group" style="grid-column: 1 / -1; text-align: right;">
-            <button type="submit" class="btn-form">Salvar Movimentação</button>
+            <button type="submit">Salvar Movimentação</button>
           </div>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- revert compact layout styles
- restore original grid and input widths on Movimentações form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687138e3328c832baaac96b6eac3a8a6