### PR TITLE
Improve despesas page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -757,6 +757,17 @@ tr.destacar {
   cursor: pointer;
   border-radius: 4px;
   margin-top: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.accordion-header .totais {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+}
+.accordion-header .totais span {
+  font-weight: 600;
 }
 .accordion-content {
   border: 1px solid #e5e7eb;
@@ -783,3 +794,4 @@ tr.destacar {
 }
 .progresso.amarelo > div { background: #f59e0b; }
 .progresso.vermelho > div { background: #ef4444; }
+.barra-progresso { flex:1; margin-left:10px; }

--- a/despesas.html
+++ b/despesas.html
@@ -43,14 +43,69 @@
         </div>
       </div>
 
-      <div id="cards-despesas" class="cards"></div>
+        <div id="cards-despesas" class="cards"></div>
+        <div style="margin:5px 0 15px 0;">
+          <label for="dias-faturamento">Dias para cálculo:</label>
+          <input type="number" id="dias-faturamento" value="25" style="width:60px;">
+        </div>
 
-      <div id="categorias-container"></div>
-      <div style="margin-top:10px;">
-        <button id="btn-adicionar-categoria">+ Adicionar categoria</button>
+        <div id="categorias-container"></div>
+        <div style="margin-top:10px;">
+          <button id="btn-adicionar-categoria">+ Adicionar categoria</button>
+        </div>
+      </main>
+    </div>
+
+    <div id="modal-despesa" class="modal">
+      <h3 id="titulo-modal-despesa">Despesa</h3>
+      <div class="form-grid form-grid-compacto">
+        <div class="form-group" style="grid-column: span 2;">
+          <label for="despesa-nome">Nome</label>
+          <input type="text" id="despesa-nome" />
+        </div>
+        <div class="form-group">
+          <label for="despesa-quantidade">Quantidade</label>
+          <input type="number" id="despesa-quantidade" />
+        </div>
+        <div class="form-group">
+          <label for="despesa-previsto">Valor previsto</label>
+          <input type="number" step="0.01" id="despesa-previsto" />
+        </div>
       </div>
-    </main>
-  </div>
+      <div class="form-group">
+        <label>Vencimentos</label>
+        <div id="despesa-vencimentos" style="display:flex;gap:5px;flex-wrap:wrap;">
+          <input type="date" />
+          <input type="date" />
+          <input type="date" />
+          <input type="date" />
+          <input type="date" />
+        </div>
+      </div>
+      <div class="form-group">
+        <label>Pagamentos</label>
+        <div id="despesa-pagamentos" style="display:flex;gap:5px;flex-wrap:wrap;">
+          <input type="number" step="0.01" />
+          <input type="number" step="0.01" />
+          <input type="number" step="0.01" />
+          <input type="number" step="0.01" />
+          <input type="number" step="0.01" />
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="despesa-observacoes">Observações</label>
+        <textarea id="despesa-observacoes" rows="2"></textarea>
+      </div>
+      <div class="form-group" style="display:flex;gap:20px;">
+        <label><input type="checkbox" id="despesa-recorrente" /> Recorrente</label>
+        <label><input type="checkbox" id="despesa-arquivado" /> Arquivado</label>
+      </div>
+      <div style="text-align:right; margin-top:10px;">
+        <button id="btn-salvar-despesa">Salvar</button>
+        <button onclick="fecharModalDespesa()">Cancelar</button>
+      </div>
+    </div>
+    <div id="fundo-modal-despesa" class="fundo-modal" onclick="fecharModalDespesa()"></div>
 
   <div id="spinner" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.2); align-items:center; justify-content:center; z-index:2000;">
     <div style="border:6px solid #ccc; border-top:6px solid #009688; border-radius:50%; width:40px; height:40px; animation:girar 1s linear infinite;"></div>

--- a/js/despesas.js
+++ b/js/despesas.js
@@ -5,6 +5,8 @@ import { formatarPreco, mostrarSpinner, esconderSpinner } from './utils.js';
 let categorias = {};
 let mesAtual = '';
 let anoAtual = '';
+let categoriaModal = '';
+let indiceModal = null;
 
 function preencherFiltros() {
   const selMes = document.getElementById('mes');
@@ -27,11 +29,11 @@ function preencherFiltros() {
 }
 
 function calcularTotalPago(item) {
-  return (item.pagamentos || []).reduce((a,b)=> a + (Number(b)||0), 0) + (Number(item.valorRealizado)||0);
+  return (item.pagamentos || []).reduce((a, b) => a + (Number(b) || 0), 0) + (Number(item.valorRealizado) || 0);
 }
 
 function porcentagem(item) {
-  const prev = Number(item.valorPrevisto)||0;
+  const prev = Number(item.valorPrevisto) || 0;
   if (!prev) return 0;
   return Math.min(100, Math.round((calcularTotalPago(item) / prev) * 100));
 }
@@ -42,22 +44,35 @@ function classeProgresso(p) {
   return 'vermelho';
 }
 
+function totaisCategoria(itens) {
+  let previsto = 0;
+  let pago = 0;
+  itens.forEach(it => {
+    previsto += Number(it.valorPrevisto) || 0;
+    pago += calcularTotalPago(it);
+  });
+  return { previsto, pago };
+}
+
 function gerarLinha(cat, idx, item) {
   const pagamentos = item.pagamentos || [];
   const totalPago = calcularTotalPago(item);
   const perc = porcentagem(item);
   const barras = `<div class="progresso ${classeProgresso(perc)}"><div style="width:${perc}%"></div></div>`;
-  const campoPagamentos = item.insumo ? formatarPreco(item.valorRealizado) :
-    [0,1,2,3,4].map(i => `<input type="number" step="0.01" value="${pagamentos[i]??''}" onchange="editarPagamento('${cat}',${idx},${i},this.value)">`).join('');
+  const campoPagamentos = item.insumo
+    ? formatarPreco(item.valorRealizado)
+    : pagamentos.map(v => formatarPreco(v)).join('<br>');
+  const btnEditar = item.insumo ? '' : `<button onclick="abrirModalEditarDespesa('${cat}',${idx})">Editar</button>`;
+  const venc = (item.vencimentos || []).join('<br>');
   return `<tr>
-    <td><input type="text" value="${item.nome||''}" onchange="editarCampo('${cat}',${idx},'nome',this.value)"></td>
-    <td><input type="number" value="${item.quantidade||''}" onchange="editarCampo('${cat}',${idx},'quantidade',this.value)"></td>
-    <td><input type="date" value="${(item.vencimentos&&item.vencimentos[0])||''}" onchange="editarVencimento('${cat}',${idx},0,this.value)"></td>
-    <td><input type="number" step="0.01" value="${item.valorPrevisto||''}" onchange="editarCampo('${cat}',${idx},'valorPrevisto',this.value)"></td>
-    <td class="pagamentos">${campoPagamentos}</td>
+    <td>${item.nome || '-'}</td>
+    <td>${item.quantidade || ''}</td>
+    <td>${venc}</td>
+    <td>${formatarPreco(item.valorPrevisto)}</td>
+    <td>${campoPagamentos}</td>
     <td>${formatarPreco(totalPago)}</td>
     <td>${barras}</td>
-    <td><textarea onchange="editarCampo('${cat}',${idx},'observacoes',this.value)">${item.observacoes||''}</textarea></td>
+    <td>${btnEditar}</td>
   </tr>`;
 }
 
@@ -66,30 +81,43 @@ function renderizarCategorias() {
   cont.innerHTML = '';
   Object.keys(categorias).forEach(cat => {
     const itens = categorias[cat];
-    const catId = 'cat_' + cat.replace(/\s+/g,'_');
-    const div = document.createElement('div');
-    div.className = 'categoria';
-    const linhas = itens.map((it,i)=> gerarLinha(cat,i,it)).join('');
-    div.innerHTML = `
-      <div class="accordion-header" onclick="toggleCategoria('${catId}')">${cat}</div>
+    const { previsto, pago } = totaisCategoria(itens);
+    const perc = previsto ? Math.min(100, Math.round((pago / previsto) * 100)) : 0;
+    const catId = 'cat_' + cat.replace(/\s+/g, '_');
+    const linhas = itens.map((it, i) => gerarLinha(cat, i, it)).join('');
+    const header = `
+      <div class="accordion-header" onclick="toggleCategoria('${catId}')">
+        <span>${cat}</span>
+        <div class="totais">
+          <span>${formatarPreco(previsto)}</span>
+          <span>${formatarPreco(pago)}</span>
+          <div class="barra-progresso">
+            <div class="progresso ${classeProgresso(perc)}"><div style="width:${perc}%"></div></div>
+          </div>
+        </div>
+      </div>`;
+    const conteudo = `
       <div class="accordion-content" id="${catId}">
         <table class="tabela">
           <thead>
             <tr>
               <th>Despesa</th>
               <th>Qtd</th>
-              <th>Vencimento</th>
+              <th>Vencimentos</th>
               <th>Valor previsto</th>
               <th>Pagamentos</th>
               <th>Total pago</th>
               <th>%</th>
-              <th>Obs</th>
+              <th></th>
             </tr>
           </thead>
-          <tbody>${linhas}</tbody>
+          <tbody>${linhas || '<tr><td colspan="8">Nenhum dado</td></tr>'}</tbody>
         </table>
-        <button onclick="adicionarDespesa('${cat}')">+ Adicionar despesa</button>
+        ${cat !== 'INSUMOS' ? `<button onclick="abrirModalNovaDespesa('${cat}')">+ Adicionar despesa</button>` : ''}
       </div>`;
+    const div = document.createElement('div');
+    div.className = 'categoria';
+    div.innerHTML = header + conteudo;
     cont.appendChild(div);
   });
 }
@@ -99,63 +127,112 @@ function atualizarCards() {
   let realizado = 0;
   Object.values(categorias).forEach(itens => {
     itens.forEach(it => {
-      previsto += Number(it.valorPrevisto)||0;
+      previsto += Number(it.valorPrevisto) || 0;
       realizado += calcularTotalPago(it);
     });
   });
+  const diferenca = previsto - realizado;
+  const dias = Number(document.getElementById('dias-faturamento').value) || 25;
+  const diario = dias ? diferenca / dias : 0;
   const cards = document.getElementById('cards-despesas');
   cards.innerHTML = `
-    <div class="resumo-card"><div class="icone">📤</div><div class="texto"><div class="titulo">A pagar</div><div class="valor" id="valor-previsto">${formatarPreco(previsto)}</div></div></div>
-    <div class="resumo-card"><div class="icone">✅</div><div class="texto"><div class="titulo">Pago</div><div class="valor">${formatarPreco(realizado)}</div></div></div>
-  `;
+    <div class="resumo-card"><div class="icone">💰</div><div class="texto"><div class="titulo">Total previsto</div><div class="valor">${formatarPreco(previsto)}</div></div></div>
+    <div class="resumo-card pago"><div class="icone">✅</div><div class="texto"><div class="titulo">Total pago</div><div class="valor">${formatarPreco(realizado)}</div></div></div>
+    <div class="resumo-card pendente"><div class="icone">📤</div><div class="texto"><div class="titulo">Diferença</div><div class="valor">${formatarPreco(diferenca)}</div></div></div>
+    <div class="resumo-card"><div class="icone">📈</div><div class="texto"><div class="titulo">Faturamento diário necessário</div><div class="valor">${formatarPreco(diario)}</div></div></div>`;
 }
 
 async function salvarDados() {
   const empresaId = await getEmpresaIdDoUsuario();
-  const ref = doc(db,'empresas',empresaId,'despesasGerais',`${anoAtual}-${mesAtual}`);
+  const ref = doc(db, 'empresas', empresaId, 'despesasGerais', `${anoAtual}-${mesAtual}`);
   const salvar = {};
   Object.keys(categorias).forEach(cat => {
     salvar[cat] = categorias[cat].filter(i => !i.insumo);
   });
-  await setDoc(ref,{categorias: salvar},{merge:true});
+  await setDoc(ref, { categorias: salvar }, { merge: true });
 }
 
-export async function editarCampo(cat, idx, campo, valor) {
-  categorias[cat][idx][campo] = valor;
-  renderizarCategorias();
-  atualizarCards();
-  await salvarDados();
-}
-
-export async function editarPagamento(cat, idx, ind, valor) {
-  if (!categorias[cat][idx].pagamentos) categorias[cat][idx].pagamentos = [];
-  categorias[cat][idx].pagamentos[ind] = valor;
-  renderizarCategorias();
-  atualizarCards();
-  await salvarDados();
-}
-
-export async function editarVencimento(cat, idx, ind, valor) {
-  if (!categorias[cat][idx].vencimentos) categorias[cat][idx].vencimentos = [];
-  categorias[cat][idx].vencimentos[ind] = valor;
-  await salvarDados();
-}
-
-export function toggleCategoria(id) {
+function toggleCategoria(id) {
   const el = document.getElementById(id);
   if (el) el.parentElement.classList.toggle('accordion-aberto');
 }
 
-export async function adicionarCategoria() {
+function abrirModalNovaDespesa(cat) {
+  categoriaModal = cat;
+  indiceModal = null;
+  document.getElementById('titulo-modal-despesa').textContent = 'Adicionar Despesa';
+  preencherModal({});
+  abrirModal();
+}
+
+function abrirModalEditarDespesa(cat, idx) {
+  categoriaModal = cat;
+  indiceModal = idx;
+  document.getElementById('titulo-modal-despesa').textContent = 'Editar Despesa';
+  preencherModal(categorias[cat][idx] || {});
+  abrirModal();
+}
+
+function abrirModal() {
+  document.getElementById('modal-despesa').style.display = 'block';
+  document.getElementById('fundo-modal-despesa').style.display = 'block';
+}
+
+function fecharModalDespesa() {
+  document.getElementById('modal-despesa').style.display = 'none';
+  document.getElementById('fundo-modal-despesa').style.display = 'none';
+}
+
+function preencherModal(item) {
+  document.getElementById('despesa-nome').value = item.nome || '';
+  document.getElementById('despesa-quantidade').value = item.quantidade || '';
+  document.getElementById('despesa-previsto').value = item.valorPrevisto || '';
+  const vencInputs = document.querySelectorAll('#despesa-vencimentos input');
+  vencInputs.forEach((el, i) => { el.value = (item.vencimentos && item.vencimentos[i]) || ''; });
+  const pagInputs = document.querySelectorAll('#despesa-pagamentos input');
+  pagInputs.forEach((el, i) => { el.value = (item.pagamentos && item.pagamentos[i]) !== undefined ? item.pagamentos[i] : ''; });
+  document.getElementById('despesa-observacoes').value = item.observacoes || '';
+  document.getElementById('despesa-recorrente').checked = !!item.recorrente;
+  document.getElementById('despesa-arquivado').checked = !!item.arquivado;
+
+  if (item.insumo) {
+    pagInputs.forEach(el => el.disabled = true);
+    document.getElementById('despesa-previsto').disabled = true;
+  } else {
+    pagInputs.forEach(el => el.disabled = false);
+    document.getElementById('despesa-previsto').disabled = false;
+  }
+}
+
+async function salvarDespesa() {
+  const nome = document.getElementById('despesa-nome').value;
+  const quantidade = document.getElementById('despesa-quantidade').value;
+  const valorPrevisto = document.getElementById('despesa-previsto').value;
+  const vencimentos = Array.from(document.querySelectorAll('#despesa-vencimentos input')).map(el => el.value).filter(v => v);
+  const pagamentos = Array.from(document.querySelectorAll('#despesa-pagamentos input')).map(el => el.value).filter(v => v !== '');
+  const observacoes = document.getElementById('despesa-observacoes').value;
+  const recorrente = document.getElementById('despesa-recorrente').checked;
+  const arquivado = document.getElementById('despesa-arquivado').checked;
+
+  const item = { nome, quantidade, valorPrevisto, vencimentos, pagamentos, observacoes, recorrente, arquivado };
+
+  if (indiceModal === null) {
+    if (!categorias[categoriaModal]) categorias[categoriaModal] = [];
+    categorias[categoriaModal].push(item);
+  } else {
+    Object.assign(categorias[categoriaModal][indiceModal], item);
+  }
+
+  renderizarCategorias();
+  atualizarCards();
+  await salvarDados();
+  fecharModalDespesa();
+}
+
+async function adicionarCategoria() {
   const nome = prompt('Nome da categoria');
   if (!nome) return;
   if (!categorias[nome]) categorias[nome] = [];
-  renderizarCategorias();
-  await salvarDados();
-}
-
-export async function adicionarDespesa(cat) {
-  categorias[cat].push({ nome:'', quantidade:'', vencimentos:[''], valorPrevisto:'', pagamentos:[], observacoes:'' });
   renderizarCategorias();
   await salvarDados();
 }
@@ -167,7 +244,7 @@ async function copiarMesAnterior() {
   let anoAnt = ano;
   if (mesAnt <= 0) { mesAnt = 12; anoAnt -= 1; }
   const empresaId = await getEmpresaIdDoUsuario();
-  const refAnt = doc(db,'empresas',empresaId,'despesasGerais',`${anoAnt}-${String(mesAnt).padStart(2,'0')}`);
+  const refAnt = doc(db, 'empresas', empresaId, 'despesasGerais', `${anoAnt}-${String(mesAnt).padStart(2, '0')}`);
   const snapAnt = await getDoc(refAnt);
   if (!snapAnt.exists()) {
     alert('Mês anterior sem dados');
@@ -180,22 +257,22 @@ async function copiarMesAnterior() {
 
 async function carregarInsumos() {
   const empresaId = await getEmpresaIdDoUsuario();
-  const movRef = query(collection(db,'empresas',empresaId,'movimentacoes'), where('tipo','==','entrada'));
+  const movRef = query(collection(db, 'empresas', empresaId, 'movimentacoes'), where('tipo', '==', 'entrada'));
   const snap = await getDocs(movRef);
   const itens = [];
   snap.forEach(docu => {
     const d = docu.data();
-    if (String(d.categoria||'').toLowerCase().includes('insum')) {
+    if (String(d.categoria || '').toLowerCase().includes('insum')) {
       const data = d.dataMovimentacao?.toDate ? d.dataMovimentacao.toDate() : new Date();
       itens.push({
         nome: d.nomeProduto,
         quantidade: d.quantidade,
-        vencimentos:[data.toISOString().slice(0,10)],
-        valorPrevisto:'',
-        pagamentos:[],
-        valorRealizado: Number(d.custoTotal)||Number(d.precoUnitario||0)*Number(d.quantidade||0),
-        observacoes: d.observacao||'',
-        insumo:true
+        vencimentos: [data.toISOString().slice(0,10)],
+        valorPrevisto: '',
+        pagamentos: [],
+        valorRealizado: Number(d.custoTotal) || Number(d.precoUnitario || 0) * Number(d.quantidade || 0),
+        observacoes: d.observacao || '',
+        insumo: true
       });
     }
   });
@@ -209,14 +286,14 @@ async function carregarDados() {
     mesAtual = document.getElementById('mes').value;
     anoAtual = document.getElementById('ano').value;
     const empresaId = await getEmpresaIdDoUsuario();
-    const ref = doc(db,'empresas',empresaId,'despesasGerais',`${anoAtual}-${mesAtual}`);
+    const ref = doc(db, 'empresas', empresaId, 'despesasGerais', `${anoAtual}-${mesAtual}`);
     const snap = await getDoc(ref);
     categorias = snap.exists() ? (snap.data().categorias || {}) : {};
     await carregarInsumos();
     renderizarCategorias();
     atualizarCards();
-  } catch(e) {
-    console.error('Erro ao carregar dados',e);
+  } catch (e) {
+    console.error('Erro ao carregar dados', e);
   } finally {
     esconderSpinner();
   }
@@ -225,7 +302,15 @@ async function carregarDados() {
 preencherFiltros();
 document.getElementById('mes').addEventListener('change', carregarDados);
 document.getElementById('ano').addEventListener('change', carregarDados);
+document.getElementById('dias-faturamento').addEventListener('input', atualizarCards);
 document.getElementById('btn-adicionar-categoria').addEventListener('click', adicionarCategoria);
 document.getElementById('btn-copiar').addEventListener('click', copiarMesAnterior);
+document.getElementById('btn-salvar-despesa').addEventListener('click', salvarDespesa);
 
 carregarDados();
+
+window.toggleCategoria = toggleCategoria;
+window.abrirModalNovaDespesa = abrirModalNovaDespesa;
+window.abrirModalEditarDespesa = abrirModalEditarDespesa;
+window.fecharModalDespesa = fecharModalDespesa;
+*


### PR DESCRIPTION
## Summary
- revamp Despesas Gerais to use accordion style category headers with totals and progress bar
- add modal to create and edit despesas
- show summary cards with total previsto, pago, diferença and faturamento diário
- update CSS for new layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a5c38bdd8832b8ee35a0c35c1e4fb