### PR TITLE
Refresh product list after entry and rename product page

### DIFF
--- a/contasReceber.html
+++ b/contasReceber.html
@@ -14,7 +14,7 @@
       <nav>
         <ul>
           <li><a href="dashboard.html">🏠 Dashboard</a></li>
-          <li><a href="produtos.html">📦 Produtos</a></li>
+          <li><a href="produtos.html">📦 Cadastro de Produtos</a></li>
           <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
           <li><a href="estoque.html">📊 Estoque</a></li>
           <li><a href="financeiro.html">💰 Financeiro</a></li>

--- a/dashboard.html
+++ b/dashboard.html
@@ -15,7 +15,7 @@
       </div>
       <nav>
         <ul>
-          <li><a href="produtos.html">📦 Produtos</a></li>
+          <li><a href="produtos.html">📦 Cadastro de Produtos</a></li>
           <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
           <li><a href="estoque.html">📊 Estoque</a></li>
           <li><a href="financeiro.html">💰 Financeiro</a></li>

--- a/despesas.html
+++ b/despesas.html
@@ -14,7 +14,7 @@
       <nav>
         <ul>
           <li><a href="dashboard.html">🏠 Dashboard</a></li>
-          <li><a href="produtos.html">📦 Produtos</a></li>
+          <li><a href="produtos.html">📦 Cadastro de Produtos</a></li>
           <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
           <li><a href="estoque.html">📊 Estoque</a></li>
           <li><a href="financeiro.html">💰 Financeiro</a></li>

--- a/estoque.html
+++ b/estoque.html
@@ -15,7 +15,7 @@
       <nav>
         <ul>
           <li><a href="dashboard.html">🏠 Dashboard</a></li>
-          <li><a href="produtos.html">📦 Produtos</a></li>
+          <li><a href="produtos.html">📦 Cadastro de Produtos</a></li>
           <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
           <li><a class="ativo" href="estoque.html">📊 Estoque</a></li>
           <li><a href="financeiro.html">💰 Financeiro</a></li>

--- a/financeiro.html
+++ b/financeiro.html
@@ -14,7 +14,7 @@
     <nav>
       <ul>
         <li><a href="dashboard.html">🏠 Dashboard</a></li>
-        <li><a href="produtos.html">📦 Produtos</a></li>
+        <li><a href="produtos.html">📦 Cadastro de Produtos</a></li>
         <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
         <li><a href="estoque.html">📊 Estoque</a></li>
         <li><a class="ativo" href="financeiro.html">💰 Financeiro</a></li>

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -107,6 +107,8 @@ async function carregarProdutos() {
     renderizarTabela(produtosCache);
   }, "❌ Erro ao carregar produtos.");
 }
+// Torna a função acessível globalmente para atualizações externas
+window.carregarProdutos = carregarProdutos;
 carregarProdutos();
 
 async function carregarMetricasDePreco(empresaId) {

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -15,7 +15,7 @@
       <nav>
         <ul>
           <li><a href="dashboard.html">🏠 Dashboard</a></li>
-          <li><a href="produtos.html">📦 Produtos</a></li>
+          <li><a href="produtos.html">📦 Cadastro de Produtos</a></li>
           <li><a href="estoque.html">📊 Estoque</a></li>
           <li><a href="financeiro.html">💰 Financeiro</a></li>
           <li><a href="despesas.html">📋 Despesas Gerais</a></li>

--- a/produtos.html
+++ b/produtos.html
@@ -3,7 +3,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8">
-  <title>Zélia - Produtos</title>
+  <title>Zélia - Cadastro de Produtos</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -30,7 +30,7 @@
 
     <!-- 🔸 Conteúdo Principal -->
     <main class="main-content">
-      <h1>📦 Produtos</h1>
+      <h1>📦 Cadastro de Produtos</h1>
 
       <!-- 🔸 Formulário -->
       <section class="form-section">

--- a/relatorios.html
+++ b/relatorios.html
@@ -17,7 +17,7 @@
     <nav>
       <ul>
         <li><a href="dashboard.html">🏠 Dashboard</a></li>
-        <li><a href="produtos.html">📦 Produtos</a></li>
+        <li><a href="produtos.html">📦 Cadastro de Produtos</a></li>
         <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
         <li><a href="estoque.html">📊 Estoque</a></li>
         <li><a href="financeiro.html">💰 Financeiro</a></li>

--- a/usuarios.html
+++ b/usuarios.html
@@ -12,7 +12,7 @@
       <nav>
         <ul>
           <li><a href="dashboard.html">🏠 Dashboard</a></li>
-          <li><a href="produtos.html">📦 Produtos</a></li>
+          <li><a href="produtos.html">📦 Cadastro de Produtos</a></li>
           <li><a href="movimentacoes.html">🔁 Movimentações</a></li>
           <li><a href="estoque.html">📊 Estoque</a></li>
           <li><a href="financeiro.html">💰 Financeiro</a></li>


### PR DESCRIPTION
## Summary
- make product list reload after stock entry by exposing `carregarProdutos`
- rename products page and navigation to "Cadastro de Produtos"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890c5c69454832bae37274deac08fc1