### PR TITLE
feat: suggest previous expenses

### DIFF
--- a/despesas.html
+++ b/despesas.html
@@ -69,7 +69,8 @@
       <div class="form-grid form-grid-compacto">
         <div class="form-group" style="grid-column: span 2;">
           <label for="despesa-nome">Nome</label>
-          <input type="text" id="despesa-nome" />
+          <input type="text" id="despesa-nome" list="lista-despesas-nomes" />
+          <datalist id="lista-despesas-nomes"></datalist>
         </div>
         <div class="form-group">
           <label for="despesa-num-parcelas">Número de parcelas</label>

--- a/js/despesas.js
+++ b/js/despesas.js
@@ -11,6 +11,7 @@ let categoriaModal = '';
 let indiceModal = null;
 let modoCategoria = 'nova';
 let categoriaOriginal = '';
+let modelosDespesas = {};
 
 function preencherFiltros() {
   const selMes = document.getElementById('mes');
@@ -215,6 +216,7 @@ function abrirModalNovaDespesa(cat) {
   indiceModal = null;
   document.getElementById('titulo-modal-despesa').textContent = 'Adicionar Despesa';
   preencherModal({});
+  carregarListaTodasDespesas();
   abrirModal();
 }
 
@@ -259,6 +261,13 @@ function preencherModal(item) {
   }
 }
 
+function preencherDespesaExistente() {
+  const nome = document.getElementById('despesa-nome').value;
+  if (modelosDespesas[nome]) {
+    preencherModal({ ...modelosDespesas[nome], nome });
+  }
+}
+
 async function salvarDespesa() {
   const nome = document.getElementById('despesa-nome').value;
   const numeroParcelas = document.getElementById('despesa-num-parcelas').value;
@@ -286,6 +295,7 @@ async function salvarDespesa() {
   renderizarCategorias();
   atualizarCards();
   await salvarDados();
+  await carregarListaTodasDespesas();
   fecharModalDespesa();
 }
 
@@ -322,6 +332,28 @@ async function carregarListaTodasCategorias() {
   const lista = document.getElementById('lista-categorias-gerais');
   if (lista) {
     lista.innerHTML = [...setCat].sort().map(c => `<option value="${c}">`).join('');
+  }
+}
+
+async function carregarListaTodasDespesas() {
+  const empresaId = await getEmpresaIdDoUsuario();
+  const snap = await getDocs(collection(db, 'empresas', empresaId, 'despesasGerais'));
+  const setDes = new Set();
+  modelosDespesas = {};
+  snap.forEach(docu => {
+    const dados = docu.data().categorias || {};
+    Object.values(dados).forEach(arr => {
+      arr.forEach(item => {
+        if (item && item.nome) {
+          setDes.add(item.nome);
+          modelosDespesas[item.nome] = { ...item, pagamentos: [], arquivado: false };
+        }
+      });
+    });
+  });
+  const lista = document.getElementById('lista-despesas-nomes');
+  if (lista) {
+    lista.innerHTML = [...setDes].sort().map(n => `<option value="${n}">`).join('');
   }
 }
 
@@ -549,8 +581,10 @@ document.getElementById('dias-faturamento').addEventListener('input', atualizarC
 document.getElementById('btn-adicionar-categoria').addEventListener('click', adicionarCategoria);
 document.getElementById('btn-salvar-despesa').addEventListener('click', salvarDespesa);
 document.getElementById('btn-salvar-categoria').addEventListener('click', salvarCategoriaModal);
+document.getElementById('despesa-nome').addEventListener('input', preencherDespesaExistente);
 console.log('Listeners registrados');
 
+carregarListaTodasDespesas();
 carregarDados();
 
 window.toggleCategoria = toggleCategoria;


### PR DESCRIPTION
## Summary
- allow reusing past expenses when adding new entries
- populate expense form from template when a previous expense name is selected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890cd026db4832b9bdcc1e4ac6f6128