### PR TITLE
Atualizar preço nas movimentações ao editar produto

### DIFF
--- a/js/produtos.js
+++ b/js/produtos.js
@@ -477,6 +477,11 @@ async function salvarAlteracoesProduto() {
       await atualizarValidadeMovimentacoes(editandoProdutoId, atualizados.validade);
     }
 
+    // 🔄 Se o preço mudou, atualiza nas movimentações relacionadas
+    if (produtoEmEdicao.precoCompra !== atualizados.precoCompra) {
+      await atualizarPrecoMovimentacoes(editandoProdutoId, atualizados.precoCompra);
+    }
+
     const conv = v => {
       if (v?.toDate) return v.toDate().toISOString();
       return v ?? '';
@@ -834,6 +839,31 @@ document.getElementById('arquivo-csv')?.addEventListener('change', (e) => {
   const file = e.target.files[0];
   if (file) importarCSV(file);
 });
+
+// ==========================
+// 🔄 Atualizar preço nas movimentações
+// ==========================
+async function atualizarPrecoMovimentacoes(produtoId, novoPreco) {
+  try {
+    const empresaId = await getEmpresaIdDoUsuario();
+    const q = query(
+      collection(db, 'empresas', empresaId, 'movimentacoes'),
+      where('produtoId', '==', produtoId)
+    );
+    const snap = await getDocs(q);
+    const promises = [];
+    snap.forEach(docSnap => {
+      const dados = docSnap.data();
+      const ref = doc(db, 'empresas', empresaId, 'movimentacoes', docSnap.id);
+      const quantidade = Number(dados.quantidade) || 0;
+      const custoTotal = quantidade * (Number(novoPreco) || 0);
+      promises.push(updateDoc(ref, { precoUnitario: novoPreco, custoTotal }));
+    });
+    await Promise.all(promises);
+  } catch (e) {
+    console.error('Erro ao atualizar preço nas movimentações:', e);
+  }
+}
 
 // ==========================
 // 🔄 Atualizar validade nas movimentações


### PR DESCRIPTION
## Summary
- Atualiza registros de movimentações com o novo preço ao editar um produto
- Recalcula o custo total das movimentações afetadas
- Evita que valores antigos influenciem as métricas de preço

## Testing
- `npm test` (falha: Could not read package.json)
- `cd functions && npm test` (falha: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68936b14e314832b92d9bb81c0e7d44c