### PR TITLE
Handle canceled financial modal with pending flag

### DIFF
--- a/js/modais.js
+++ b/js/modais.js
@@ -56,9 +56,16 @@ export function cadastrarOutroProduto() {
 // ✅ Modal de Confirmação
 
 let acaoConfirmada = null;
+let acaoCancelada = null;
 let handlerTecladoConfirmacao = null;
 
-export function abrirModalConfirmacao(texto, acao) {
+export function abrirModalConfirmacao(
+  texto,
+  acaoConfirmar,
+  acaoCancelar = null,
+  textoConfirmar = '✅ Sim',
+  textoCancelar = '❌ Não'
+) {
   const textoEl = document.getElementById("texto-confirmacao");
   if (textoEl) {
     textoEl.textContent = texto;
@@ -67,11 +74,15 @@ export function abrirModalConfirmacao(texto, acao) {
   }
 
   abrirModal('modal-confirmacao');
-  acaoConfirmada = acao;
+  acaoConfirmada = acaoConfirmar;
+  acaoCancelada = acaoCancelar;
 
   const btnConfirmar = document.getElementById("btn-confirmar-acao");
   const btnCancelar = document.getElementById("btn-cancelar-confirmacao");
   const modal = document.getElementById("modal-confirmacao");
+
+  if (btnConfirmar) btnConfirmar.textContent = textoConfirmar;
+  if (btnCancelar) btnCancelar.textContent = textoCancelar;
 
   btnConfirmar?.focus();
 
@@ -88,6 +99,9 @@ export function abrirModalConfirmacao(texto, acao) {
       if (document.activeElement === btnConfirmar) {
         confirmarAcao();
       } else if (document.activeElement === btnCancelar) {
+        if (typeof acaoCancelada === 'function') {
+          acaoCancelada();
+        }
         cancelarConfirmacao();
       }
     }
@@ -99,6 +113,7 @@ export function abrirModalConfirmacao(texto, acao) {
 export function cancelarConfirmacao() {
   fecharModal('modal-confirmacao');
   acaoConfirmada = null;
+  acaoCancelada = null;
   const modal = document.getElementById('modal-confirmacao');
   if (handlerTecladoConfirmacao) {
     modal.removeEventListener('keydown', handlerTecladoConfirmacao);
@@ -138,7 +153,12 @@ document.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  btnCancelar.addEventListener("click", cancelarConfirmacao);
+  btnCancelar.addEventListener("click", () => {
+    if (typeof acaoCancelada === 'function') {
+      acaoCancelada();
+    }
+    cancelarConfirmacao();
+  });
   btnConfirmar.addEventListener("click", confirmarAcao);
 });
 

--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -5,16 +5,19 @@ import {
   collection,
   addDoc,
   updateDoc,
+  deleteDoc,
   doc,
   getDoc,
   getDocs,
   query,
   where,
-  Timestamp
+  Timestamp,
+  deleteField
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
 import { mostrarErro, normalizarTexto, parseDataLocal, formatarCompraIdBR, formatarPreco, formatarDataBrasileira } from './utils.js';
 import { registrarHistorico } from './historico.js';
+import { abrirModalConfirmacao } from './modais.js';
 
 let produtoCadastroAtual = null;
 let dadosFinanceiroAtual = null;
@@ -139,6 +142,42 @@ export function fecharModalEntrada() {
     handlerTecladoEntrada = null;
   }
 }
+
+window.cancelarEntradaFinanceira = function () {
+  if (!produtoCadastroAtual?.novoCadastro) {
+    fecharModalEntrada();
+    return;
+  }
+
+  abrirModalConfirmacao(
+    "⚠️ As informações financeiras não serão registradas.\nDeseja manter o produto no estoque mesmo assim?\nVocê poderá adicionar os dados financeiros depois.",
+    async () => {
+      try {
+        const empresaId = await getEmpresaIdDoUsuario();
+        const ref = doc(db, "empresas", empresaId, "produtos", produtoCadastroAtual.id);
+        await updateDoc(ref, { entradaFinanceiraPendente: true });
+        fecharModalEntrada();
+        alert("Produto mantido sem financeiro.");
+        if (window.carregarProdutos) window.carregarProdutos();
+      } catch (e) {
+        console.error("Erro ao marcar pendência financeira:", e);
+      }
+    },
+    async () => {
+      try {
+        const empresaId = await getEmpresaIdDoUsuario();
+        await deleteDoc(doc(db, "empresas", empresaId, "produtos", produtoCadastroAtual.id));
+        fecharModalEntrada();
+        alert("Produto removido.");
+        if (window.carregarProdutos) window.carregarProdutos();
+      } catch (e) {
+        console.error("Erro ao remover produto:", e);
+      }
+    },
+    "✅ Sim, manter o produto (adicionarei depois)",
+    "❌ Não, apagar produto"
+  );
+};
 
 async function preencherDadosFinanceiro(compraId) {
   if (!compraId) return;
@@ -336,7 +375,9 @@ window.confirmarEntradaEstoque = async function () {
     const novaQuantidade = (produto.quantidade || 0) + quantidade;
     await updateDoc(produtoRef, {
       quantidade: novaQuantidade,
-      dataEntrada: dataTimestamp
+      dataEntrada: dataTimestamp,
+      precoCompra: produtoCadastroAtual.precoCompra,
+      entradaFinanceiraPendente: deleteField()
     });
     await registrarHistorico(
       produtoCadastroAtual.id,

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -356,7 +356,8 @@ async function adicionarProduto() {
             precoCompra,
             dataEntrada,
             validade,
-            lote
+            lote,
+            novoCadastro: true
           });
         } catch (erroModal) {
           console.error("❌ Erro ao abrir modal de entrada:", erroModal);
@@ -416,6 +417,13 @@ window.editarProduto = async function (id) {
     btn.textContent = '💾 Salvar Alterações';
     const cancelar = document.getElementById('cancelar-edicao');
     if (cancelar) cancelar.style.display = 'inline-block';
+
+    const finContainer = document.getElementById('financeiro-pendente-container');
+    const finBtn = document.getElementById('btn-adicionar-financeiro');
+    if (finContainer && finBtn) {
+      finContainer.style.display = 'block';
+      finBtn.textContent = p.entradaFinanceiraPendente ? '📄 Adicionar entrada financeira' : '✏️ Alterar dados financeiros';
+    }
 
     const form = document.getElementById('form-produto');
     form.dataset.editando = 'true';
@@ -500,6 +508,8 @@ async function salvarAlteracoesProduto() {
     if (btnSalvar) btnSalvar.textContent = 'Salvar Produto';
     const cancelar = document.getElementById('cancelar-edicao');
     if (cancelar) cancelar.style.display = 'none';
+    const finContainer = document.getElementById('financeiro-pendente-container');
+    if (finContainer) finContainer.style.display = 'none';
     form.dataset.editando = '';
     carregarProdutos();
     editandoProdutoId = null;
@@ -519,6 +529,8 @@ function cancelarEdicao() {
   if (btnSalvar) btnSalvar.textContent = 'Salvar Produto';
   const cancelar = document.getElementById('cancelar-edicao');
   if (cancelar) cancelar.style.display = 'none';
+  const finContainer = document.getElementById('financeiro-pendente-container');
+  if (finContainer) finContainer.style.display = 'none';
   editandoProdutoId = null;
   docRefEmEdicao = null;
   produtoEmEdicao = null;
@@ -708,6 +720,7 @@ async function gerarESalvarCSV() {
 const form = document.getElementById("form-produto");
 const btn = document.querySelector("#form-produto button[type='submit']");
 const btnCancelar = document.getElementById('cancelar-edicao');
+const btnFinanceiro = document.getElementById('btn-adicionar-financeiro');
 let listenerPadrao = null;
 
 if (form && btn) {
@@ -724,6 +737,32 @@ if (form && btn) {
 
 if (btnCancelar) {
   btnCancelar.addEventListener('click', cancelarEdicao);
+}
+
+if (btnFinanceiro) {
+  btnFinanceiro.addEventListener('click', () => {
+    if (!editandoProdutoId) return;
+    const nome = document.getElementById('nome').value.trim();
+    const categoria = document.getElementById('categoria').value.trim();
+    const fornecedor = document.getElementById('fornecedor').value.trim();
+    const quantidade = parseInt(document.getElementById('quantidade').value) || 0;
+    const precoCompra = parseFloat(document.getElementById('precoCompra').value.replace(',', '.')) || 0;
+    const validade = parseDataLocal(document.getElementById('validade').value);
+    const dataEntrada = parseDataLocal(document.getElementById('dataEntrada').value);
+    const lote = document.getElementById('lote')?.value?.trim() || '';
+    abrirModalEntrada({
+      id: editandoProdutoId,
+      nome,
+      categoria,
+      fornecedor,
+      unidadeMedida: 'unidade',
+      quantidade,
+      precoCompra,
+      dataEntrada,
+      validade,
+      lote
+    });
+  });
 }
 
 // 🔧 Preencher data de entrada com a data atual ao carregar a página

--- a/produtos.html
+++ b/produtos.html
@@ -102,6 +102,9 @@
             <button id="cancelar-edicao" type="button" style="display:none;margin-right:10px;">❌ Cancelar Alterações</button>
             <button type="submit">Salvar Produto</button>
           </div>
+          <div class="form-group full-width" id="financeiro-pendente-container" style="display:none; text-align:right;">
+            <button type="button" id="btn-adicionar-financeiro">📄 Adicionar entrada financeira</button>
+          </div>
         </form>
       </section>
 
@@ -163,7 +166,7 @@
   </div>
 
   <!-- 🔧 Fundo do Modal de Entrada -->
-  <div id="fundo-modal" class="fundo-modal" onclick="fecharModalEntrada()"></div>
+  <div id="fundo-modal" class="fundo-modal" onclick="cancelarEntradaFinanceira()"></div>
 
   <!-- ✅ Modal de Entrada de Produto -->
   <div id="modal-entrada" class="modal">
@@ -202,7 +205,7 @@
       <textarea id="entrada-observacoes" rows="2"></textarea>
 
       <div style="margin-top: 15px; text-align: right;">
-        <button id="btn-entrada-cancelar" onclick="fecharModalEntrada()">Cancelar</button>
+        <button id="btn-entrada-cancelar" onclick="cancelarEntradaFinanceira()">Cancelar</button>
         <button id="btn-entrada-confirmar" onclick="confirmarEntradaEstoque()">Confirmar Entrada</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add flexible confirmation modal capable of custom button labels and cancel callbacks.
- When the financial modal is canceled during product creation, ask whether to keep or delete the product, marking `entradaFinanceiraPendente` when kept.
- Expose a button on the product edit screen to add or edit financial data later and remove the pending flag once confirmed.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936e9af7e8832bb21cde21119fbd44