### PR TITLE
Reuse parcel dates for existing purchase entries

### DIFF
--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -232,6 +232,9 @@ async function preencherDadosFinanceiro(compraId) {
       } else {
         atualizarParcelasPreview();
       }
+    } else {
+      dadosFinanceiroAtual = null;
+      atualizarParcelasPreview();
     }
   } catch (e) {
     console.error("Erro ao carregar dados financeiros:", e);
@@ -392,15 +395,30 @@ window.confirmarEntradaEstoque = async function () {
 
     const valoresParcelas = dividirValorEmParcelas(custoTotal, numParcelas);
     const parcelas = [];
-    for (let i = 0; i < numParcelas; i++) {
-      const input = document.getElementById(`parcela-venc-${i}`);
-      if (input) {
+    if (finDocExistente && !parcelasAlteradas) {
+      const parcelasExistentes = Array.isArray(finDocExistente.data().parcelas)
+        ? finDocExistente.data().parcelas
+        : [];
+      for (let i = 0; i < numParcelas; i++) {
+        const vencimento = parcelasExistentes[i]?.vencimento || document.getElementById(`parcela-venc-${i}`)?.value;
         parcelas.push({
           numero: i + 1,
           valor: valoresParcelas[i],
-          vencimento: input.value,
+          vencimento,
           status: "pendente"
         });
+      }
+    } else {
+      for (let i = 0; i < numParcelas; i++) {
+        const input = document.getElementById(`parcela-venc-${i}`);
+        if (input) {
+          parcelas.push({
+            numero: i + 1,
+            valor: valoresParcelas[i],
+            vencimento: input.value,
+            status: "pendente"
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Reuse existing parcel due dates when adding items to an already registered purchase
- Reset financial preview when purchase ID isn't found to avoid stale data

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/zeliaestoque/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6893bd0101b8832b9c612586bafdf963