### PR TITLE
Exibir mais informações nos detalhes do produto

### DIFF
--- a/js/produtos.js
+++ b/js/produtos.js
@@ -791,12 +791,20 @@ window.verDetalhes = async function(id) {
     document.getElementById('det-nome').textContent = p.nome || '-';
     document.getElementById('det-categoria').textContent = p.categoria || '-';
     document.getElementById('det-quantidade').textContent = p.quantidade ?? '-';
+    document.getElementById('det-quantidadeMinima').textContent = p.quantidadeMinima ?? '-';
     document.getElementById('det-preco').textContent =
       p.precoCompra !== undefined && p.precoCompra !== null
         ? formatarPreco(Number(p.precoCompra) || 0)
         : '-';
+    const valorTotal = (Number(p.quantidade) || 0) * (Number(p.precoCompra) || 0);
+    document.getElementById('det-valorTotal').textContent = formatarPreco(valorTotal);
     document.getElementById('det-fornecedor').textContent = p.fornecedor || '-';
+    document.getElementById('det-prazoEntrega').textContent = p.prazoEntregaDias ?? '-';
+    document.getElementById('det-lote').textContent = p.lote || '-';
+    document.getElementById('det-localizacao').textContent = p.localizacao || '-';
     document.getElementById('det-validade').textContent = formatarData(p.validade);
+    document.getElementById('det-dataEntrada').textContent = formatarData(p.dataEntrada);
+    document.getElementById('det-observacoes').textContent = p.observacoes || '-';
 
     const historico = await carregarHistorico(id);
     const lista = document.getElementById('lista-historico');

--- a/produtos.html
+++ b/produtos.html
@@ -231,9 +231,16 @@
         <p><strong>Nome:</strong> <span id="det-nome"></span></p>
         <p><strong>Categoria:</strong> <span id="det-categoria"></span></p>
         <p><strong>Quantidade:</strong> <span id="det-quantidade"></span></p>
-        <p><strong>Preço:</strong> <span id="det-preco"></span></p>
+        <p><strong>Quantidade Mínima:</strong> <span id="det-quantidadeMinima"></span></p>
+        <p><strong>Preço Unitário:</strong> <span id="det-preco"></span></p>
+        <p><strong>Valor Total em Estoque:</strong> <span id="det-valorTotal"></span></p>
         <p><strong>Fornecedor:</strong> <span id="det-fornecedor"></span></p>
+        <p><strong>Prazo de Entrega (dias):</strong> <span id="det-prazoEntrega"></span></p>
+        <p><strong>Lote:</strong> <span id="det-lote"></span></p>
+        <p><strong>Localização:</strong> <span id="det-localizacao"></span></p>
         <p><strong>Validade:</strong> <span id="det-validade"></span></p>
+        <p><strong>Data de Entrada:</strong> <span id="det-dataEntrada"></span></p>
+        <p><strong>Observações:</strong> <span id="det-observacoes"></span></p>
       </div>
       <div id="aba-historico" style="display:none; margin-top:10px;">
         <div id="lista-historico"></div>


### PR DESCRIPTION
## Summary
- Expandir modal de detalhes do produto para mostrar dados completos
- Incluir informações financeiras e de estoque no modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960ff49840832bbae417cf2d4963eb