### PR TITLE
feat: add barcode and qr support

### DIFF
--- a/js/labels.js
+++ b/js/labels.js
@@ -1,0 +1,44 @@
+/**
+ * labels.js - geração simples de etiquetas para produtos.
+ *
+ * Dependências em tempo de execução (via CDN):
+ * - jsPDF
+ * - JsBarcode
+ * - qrcode
+ */
+
+import JsBarcode from 'https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.esm.min.js';
+import { jsPDF } from 'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.es.min.js';
+import QRCode from 'https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.esm.js';
+
+/**
+ * Gera um PDF com uma etiqueta simples contendo nome, lote, validade,
+ * localização e códigos de barras/QR quando fornecidos.
+ */
+export async function imprimirEtiquetaProduto(prod) {
+  const doc = new jsPDF();
+  const x = 10;
+  let y = 10;
+  doc.setFontSize(12);
+  doc.text(prod.nome || '', x, y);
+  y += 6;
+  if (prod.lote) { doc.text(`Lote: ${prod.lote}`, x, y); y += 6; }
+  if (prod.validade) { doc.text(`Val.: ${prod.validade}`, x, y); y += 6; }
+  if (prod.localizacao) { doc.text(`Loc.: ${prod.localizacao}`, x, y); y += 6; }
+
+  if (prod.barcode) {
+    const bcCanvas = document.createElement('canvas');
+    JsBarcode(bcCanvas, prod.barcode, { format: 'CODE128', width: 1, height: 40 });
+    const img = bcCanvas.toDataURL('image/png');
+    doc.addImage(img, 'PNG', x, y, 80, 20);
+    y += 25;
+  }
+
+  if (prod.qrcode) {
+    const qrData = await QRCode.toDataURL(prod.qrcode);
+    doc.addImage(qrData, 'PNG', x, y, 25, 25);
+    y += 30;
+  }
+
+  doc.save('etiqueta.pdf');
+}

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -16,6 +16,7 @@ import {
   formatarPreco
 } from './utils.js';
 import { registrarHistorico } from './historico.js';
+import { abrirScanner } from './scanner.js';
 
 import {
   abrirModalConfirmacao,
@@ -87,6 +88,18 @@ document.addEventListener("DOMContentLoaded", () => {
         document.getElementById('tipo-movimentacao')?.focus();
       }, 10);
     }
+  }
+
+  const btnScan = document.getElementById('btn-ler-barcode-mov');
+  if (btnScan) {
+    btnScan.addEventListener('click', async () => {
+      try {
+        const codigo = await abrirScanner();
+        if (codigo) preencherProdutoPorCodigo(codigo.trim());
+      } catch (e) {
+        console.error('scanner mov', e);
+      }
+    });
   }
 });
 
@@ -176,6 +189,18 @@ function atualizarDatalistsFiltros() {
 }
 
 carregarProdutos();
+
+async function preencherProdutoPorCodigo(codigo) {
+  const prod = produtosCache.find(p => p.barcode === codigo || (p.altBarcodes || []).includes(codigo));
+  if (prod) {
+    const campo = document.getElementById('nome-produto');
+    if (campo) campo.value = prod.nome;
+    return;
+  }
+  if (confirm('Produto não encontrado. Deseja cadastrá-lo?')) {
+    window.location.href = `produtos.html?barcode=${encodeURIComponent(codigo)}`;
+  }
+}
 
 // ==========================
 // 🔍 Obter preço de uma validade específica

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -25,6 +25,9 @@ import {
   abrirModalEntrada
 } from './modalEntrada.js';
 
+import { abrirScanner } from './scanner.js';
+import { imprimirEtiquetaProduto } from './labels.js';
+
 import {
   normalizarTexto,
   mostrarMensagem,
@@ -77,6 +80,8 @@ let nomesProdutosUnicos = [];
 let timeoutSugestaoNome = null;
 let indiceSugestaoNome = -1;
 let itensSugestaoNome = [];
+
+const barcodeParam = new URLSearchParams(window.location.search).get('barcode');
 
 
 // ==========================
@@ -293,6 +298,8 @@ async function adicionarProduto() {
       const observacoes = document.getElementById("observacoes").value.trim();
       const localizacao = document.getElementById("localizacao").value.trim();
       const lote = document.getElementById("lote")?.value?.trim() || "";
+      const barcode = document.getElementById('barcode').value.trim();
+      const qrcode = document.getElementById('qrcode').value.trim();
 
       // console.log("🔸 Nome:", nome);
       // console.log("🔸 Categoria:", categoria);
@@ -325,6 +332,15 @@ async function adicionarProduto() {
         return;
       }
 
+      if (barcode) {
+        const qBar = query(collection(db, 'empresas', empresaId, 'produtos'), where('barcode', '==', barcode));
+        const snapBar = await getDocs(qBar);
+        if (!snapBar.empty) {
+          alert('❗ Código de barras já cadastrado em outro produto.');
+          return;
+        }
+      }
+
       try {
         const docRef = await addDoc(collection(db, "empresas", empresaId, "produtos"), {
           nome,
@@ -339,13 +355,19 @@ async function adicionarProduto() {
           prazoEntregaDias,
           observacoes,
           localizacao,
-          lote
+          lote,
+          barcode,
+          altBarcodes: [],
+          qrcode
         });
 
         // console.log("✅ Produto adicionado ao Firestore:", docRef.id);
         mostrarMensagem("✅ Produto adicionado com sucesso!");
 
         try {
+          if (!qrcode) {
+            await updateDoc(docRef, { qrcode: docRef.id });
+          }
           abrirModalEntrada({
             id: docRef.id,
             nome,
@@ -412,6 +434,8 @@ window.editarProduto = async function (id) {
     document.getElementById('observacoes').value = p.observacoes || '';
     document.getElementById('localizacao').value = p.localizacao || '';
     document.getElementById('lote').value = p.lote || '';
+    document.getElementById('barcode').value = p.barcode || '';
+    document.getElementById('qrcode').value = p.qrcode || '';
 
     const btn = document.querySelector('#form-produto button[type="submit"]');
     btn.textContent = '💾 Salvar Alterações';
@@ -433,6 +457,19 @@ window.editarProduto = async function (id) {
 async function salvarAlteracoesProduto() {
   const form = document.getElementById('form-produto');
   if (!docRefEmEdicao || !form) return;
+
+  const barcode = document.getElementById('barcode').value.trim();
+  const qrcode = document.getElementById('qrcode').value.trim();
+
+  if (barcode && barcode !== (produtoEmEdicao.barcode || '')) {
+    const empresaId = await getEmpresaIdDoUsuario();
+    const qBar = query(collection(db, 'empresas', empresaId, 'produtos'), where('barcode', '==', barcode));
+    const snapBar = await getDocs(qBar);
+    if (!snapBar.empty) {
+      alert('❗ Código de barras já cadastrado em outro produto.');
+      return;
+    }
+  }
 
   const atualizados = {
     nome: document.getElementById('nome').value.trim(),
@@ -456,7 +493,9 @@ async function salvarAlteracoesProduto() {
     fornecedor: document.getElementById('fornecedor').value.trim(),
     observacoes: document.getElementById('observacoes').value.trim(),
     localizacao: document.getElementById('localizacao').value.trim(),
-    lote: document.getElementById('lote').value.trim()
+    lote: document.getElementById('lote').value.trim(),
+    barcode,
+    qrcode: qrcode || editandoProdutoId
   };
 
   try {
@@ -721,7 +760,15 @@ const form = document.getElementById("form-produto");
 const btn = document.querySelector("#form-produto button[type='submit']");
 const btnCancelar = document.getElementById('cancelar-edicao');
 const btnFinanceiro = document.getElementById('btn-adicionar-financeiro');
+const btnScan = document.getElementById('btn-ler-barcode');
+const btnEtiqueta = document.getElementById('btn-imprimir-etiqueta');
+const btnGerarQr = document.getElementById('btn-gerar-qr');
 let listenerPadrao = null;
+
+if (barcodeParam) {
+  const campoBarcode = document.getElementById('barcode');
+  if (campoBarcode) campoBarcode.value = barcodeParam;
+}
 
 if (form && btn) {
   listenerPadrao = (e) => {
@@ -762,6 +809,44 @@ if (btnFinanceiro) {
       validade,
       lote
     });
+  });
+}
+
+if (btnScan) {
+  btnScan.addEventListener('click', async () => {
+    try {
+      const codigo = await abrirScanner();
+      if (codigo) document.getElementById('barcode').value = codigo.trim();
+    } catch (e) {
+      console.error('scanner', e);
+    }
+  });
+}
+
+if (btnEtiqueta) {
+  btnEtiqueta.addEventListener('click', async () => {
+    const prod = {
+      nome: document.getElementById('nome').value.trim(),
+      lote: document.getElementById('lote').value.trim(),
+      validade: document.getElementById('validade').value,
+      localizacao: document.getElementById('localizacao').value.trim(),
+      barcode: document.getElementById('barcode').value.trim(),
+      qrcode: document.getElementById('qrcode').value.trim() || editandoProdutoId
+    };
+    try {
+      await imprimirEtiquetaProduto(prod);
+    } catch (e) {
+      console.error('imprimir etiqueta', e);
+    }
+  });
+}
+
+if (btnGerarQr) {
+  btnGerarQr.addEventListener('click', () => {
+    const campoQr = document.getElementById('qrcode');
+    if (!campoQr.value && editandoProdutoId) {
+      campoQr.value = editandoProdutoId;
+    }
   });
 }
 

--- a/js/scanner.js
+++ b/js/scanner.js
@@ -1,0 +1,80 @@
+/**
+ * scanner.js - Utilitário simples para leitura de códigos de barras e QR codes.
+ *
+ * Usa a API BarcodeDetector quando disponível e faz fallback para ZXing
+ * carregado via CDN. Retorna uma Promise que resolve com o valor lido
+ * ou rejeita em caso de erro/fechamento.
+ */
+
+export async function abrirScanner () {
+  return new Promise(async (resolve, reject) => {
+    const overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.width = '100%';
+    overlay.style.height = '100%';
+    overlay.style.background = 'rgba(0,0,0,0.8)';
+    overlay.style.display = 'flex';
+    overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'center';
+    overlay.style.zIndex = '9999';
+
+    const video = document.createElement('video');
+    video.style.maxWidth = '90%';
+    video.style.maxHeight = '90%';
+    overlay.appendChild(video);
+    document.body.appendChild(overlay);
+
+    let stream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+      video.srcObject = stream;
+      await video.play();
+    } catch (err) {
+      cleanup();
+      reject(err);
+      return;
+    }
+
+    function cleanup () {
+      if (stream) stream.getTracks().forEach(t => t.stop());
+      overlay.remove();
+    }
+
+    const handleResult = code => {
+      cleanup();
+      resolve(code);
+    };
+
+    if ('BarcodeDetector' in window) {
+      const detector = new BarcodeDetector({ formats: ['qr_code', 'ean_13', 'code_128'] });
+      const scan = async () => {
+        try {
+          const results = await detector.detect(video);
+          if (results && results[0]) {
+            handleResult(results[0].rawValue);
+            return;
+          }
+        } catch (e) {
+          console.error('BarcodeDetector error', e);
+        }
+        requestAnimationFrame(scan);
+      };
+      scan();
+    } else {
+      const { BrowserMultiFormatReader } = await import('https://cdn.jsdelivr.net/npm/@zxing/library@0.20.0/esm/index.min.js');
+      const codeReader = new BrowserMultiFormatReader();
+      codeReader.decodeFromVideoDevice(null, video, (result, err) => {
+        if (result) {
+          handleResult(result.getText());
+        }
+      });
+    }
+
+    overlay.addEventListener('click', () => {
+      cleanup();
+      reject(new Error('cancelled'));
+    });
+  });
+}

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -38,7 +38,10 @@
         <div class="form-grid" style="grid-template-columns: repeat(6, 1fr);">
           <div class="form-group" style="grid-column: span 2; position: relative;">
             <label>Produto:</label>
-            <input type="text" id="nome-produto" placeholder="Nome do Produto" required>
+            <div style="display:flex;gap:5px;">
+              <input type="text" id="nome-produto" placeholder="Nome do Produto" required>
+              <button type="button" id="btn-ler-barcode-mov">Ler código</button>
+            </div>
             <ul id="sugestoes-produto" class="autocomplete-list"></ul>
           </div>
 

--- a/produtos.html
+++ b/produtos.html
@@ -98,6 +98,23 @@
             <input type="text" id="localizacao" />
           </div>
 
+          <div class="form-group">
+            <label>Código de barras:</label>
+            <div style="display:flex;gap:5px;">
+              <input type="text" id="barcode" />
+              <button type="button" id="btn-ler-barcode">Ler código</button>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label>QR interno:</label>
+            <div style="display:flex;gap:5px;">
+              <input type="text" id="qrcode" />
+              <button type="button" id="btn-gerar-qr">Gerar QR interno</button>
+              <button type="button" id="btn-imprimir-etiqueta">Imprimir etiqueta</button>
+            </div>
+          </div>
+
           <div class="form-group full-width" style="text-align: right;">
             <button id="cancelar-edicao" type="button" style="display:none;margin-right:10px;">❌ Cancelar Alterações</button>
             <button type="submit">Salvar Produto</button>


### PR DESCRIPTION
## Summary
- add barcode and internal QR fields to product form
- allow scanning codes and auto-filling product during movements
- provide basic scanner utility and label generator

## Testing
- `npm test` *(fails: no package.json)*
- `cd functions && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68961cffebb4832bbc9eca77639fff31