### PR TITLE
Simplify product scan flow and enhance barcode reader

### DIFF
--- a/js/produtos.js
+++ b/js/produtos.js
@@ -26,7 +26,6 @@ import {
 } from './modalEntrada.js';
 
 import { abrirScanner } from './scanner.js';
-import { imprimirEtiquetaProduto } from './labels.js';
 
 import {
   normalizarTexto,
@@ -299,7 +298,6 @@ async function adicionarProduto() {
       const localizacao = document.getElementById("localizacao").value.trim();
       const lote = document.getElementById("lote")?.value?.trim() || "";
       const barcode = document.getElementById('barcode').value.trim();
-      const qrcode = document.getElementById('qrcode').value.trim();
 
       // console.log("🔸 Nome:", nome);
       // console.log("🔸 Categoria:", categoria);
@@ -357,17 +355,13 @@ async function adicionarProduto() {
           localizacao,
           lote,
           barcode,
-          altBarcodes: [],
-          qrcode
+          altBarcodes: []
         });
 
         // console.log("✅ Produto adicionado ao Firestore:", docRef.id);
         mostrarMensagem("✅ Produto adicionado com sucesso!");
 
         try {
-          if (!qrcode) {
-            await updateDoc(docRef, { qrcode: docRef.id });
-          }
           abrirModalEntrada({
             id: docRef.id,
             nome,
@@ -435,7 +429,6 @@ window.editarProduto = async function (id) {
     document.getElementById('localizacao').value = p.localizacao || '';
     document.getElementById('lote').value = p.lote || '';
     document.getElementById('barcode').value = p.barcode || '';
-    document.getElementById('qrcode').value = p.qrcode || '';
 
     const btn = document.querySelector('#form-produto button[type="submit"]');
     btn.textContent = '💾 Salvar Alterações';
@@ -459,7 +452,6 @@ async function salvarAlteracoesProduto() {
   if (!docRefEmEdicao || !form) return;
 
   const barcode = document.getElementById('barcode').value.trim();
-  const qrcode = document.getElementById('qrcode').value.trim();
 
   if (barcode && barcode !== (produtoEmEdicao.barcode || '')) {
     const empresaId = await getEmpresaIdDoUsuario();
@@ -494,8 +486,7 @@ async function salvarAlteracoesProduto() {
     observacoes: document.getElementById('observacoes').value.trim(),
     localizacao: document.getElementById('localizacao').value.trim(),
     lote: document.getElementById('lote').value.trim(),
-    barcode,
-    qrcode: qrcode || editandoProdutoId
+    barcode
   };
 
   try {
@@ -761,8 +752,6 @@ const btn = document.querySelector("#form-produto button[type='submit']");
 const btnCancelar = document.getElementById('cancelar-edicao');
 const btnFinanceiro = document.getElementById('btn-adicionar-financeiro');
 const btnScan = document.getElementById('btn-ler-barcode');
-const btnEtiqueta = document.getElementById('btn-imprimir-etiqueta');
-const btnGerarQr = document.getElementById('btn-gerar-qr');
 let listenerPadrao = null;
 
 if (barcodeParam) {
@@ -823,32 +812,6 @@ if (btnScan) {
   });
 }
 
-if (btnEtiqueta) {
-  btnEtiqueta.addEventListener('click', async () => {
-    const prod = {
-      nome: document.getElementById('nome').value.trim(),
-      lote: document.getElementById('lote').value.trim(),
-      validade: document.getElementById('validade').value,
-      localizacao: document.getElementById('localizacao').value.trim(),
-      barcode: document.getElementById('barcode').value.trim(),
-      qrcode: document.getElementById('qrcode').value.trim() || editandoProdutoId
-    };
-    try {
-      await imprimirEtiquetaProduto(prod);
-    } catch (e) {
-      console.error('imprimir etiqueta', e);
-    }
-  });
-}
-
-if (btnGerarQr) {
-  btnGerarQr.addEventListener('click', () => {
-    const campoQr = document.getElementById('qrcode');
-    if (!campoQr.value && editandoProdutoId) {
-      campoQr.value = editandoProdutoId;
-    }
-  });
-}
 
 // 🔧 Preencher data de entrada com a data atual ao carregar a página
 const campoDataEntrada = document.getElementById("dataEntrada");

--- a/js/scanner.js
+++ b/js/scanner.js
@@ -23,6 +23,7 @@ export async function abrirScanner () {
     const video = document.createElement('video');
     video.style.maxWidth = '90%';
     video.style.maxHeight = '90%';
+    video.setAttribute('playsinline', true);
     overlay.appendChild(video);
     document.body.appendChild(overlay);
 
@@ -30,6 +31,7 @@ export async function abrirScanner () {
     try {
       stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
       video.srcObject = stream;
+      video.muted = true;
       await video.play();
     } catch (err) {
       cleanup();
@@ -48,7 +50,7 @@ export async function abrirScanner () {
     };
 
     if ('BarcodeDetector' in window) {
-      const detector = new BarcodeDetector({ formats: ['qr_code', 'ean_13', 'code_128'] });
+      const detector = new BarcodeDetector({ formats: ['qr_code', 'ean_13', 'ean_8', 'code_128', 'code_39', 'code_93', 'upc_a', 'upc_e', 'itf', 'codabar', 'data_matrix'] });
       const scan = async () => {
         try {
           const results = await detector.detect(video);

--- a/produtos.html
+++ b/produtos.html
@@ -99,19 +99,10 @@
           </div>
 
           <div class="form-group">
-            <label>Código de barras:</label>
+            <label>Código (QR ou de barras):</label>
             <div style="display:flex;gap:5px;">
               <input type="text" id="barcode" />
               <button type="button" id="btn-ler-barcode">Ler código</button>
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label>QR interno:</label>
-            <div style="display:flex;gap:5px;">
-              <input type="text" id="qrcode" />
-              <button type="button" id="btn-gerar-qr">Gerar QR interno</button>
-              <button type="button" id="btn-imprimir-etiqueta">Imprimir etiqueta</button>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Remove internal QR/etiqueta buttons from product form
- Drop QR-related code from produto scripts
- Broaden scanner barcode formats and improve mobile video setup

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896284d1b08832ba82b3f4228ad813e