### PR TITLE
Enable camera barcode scanning on product page

### DIFF
--- a/js/produtos.js
+++ b/js/produtos.js
@@ -25,7 +25,6 @@ import {
   abrirModalEntrada
 } from './modalEntrada.js';
 
-import { abrirScanner } from './scanner.js';
 
 import {
   normalizarTexto,
@@ -751,7 +750,6 @@ const form = document.getElementById("form-produto");
 const btn = document.querySelector("#form-produto button[type='submit']");
 const btnCancelar = document.getElementById('cancelar-edicao');
 const btnFinanceiro = document.getElementById('btn-adicionar-financeiro');
-const btnScan = document.getElementById('btn-ler-barcode');
 let listenerPadrao = null;
 
 if (barcodeParam) {
@@ -801,16 +799,6 @@ if (btnFinanceiro) {
   });
 }
 
-if (btnScan) {
-  btnScan.addEventListener('click', async () => {
-    try {
-      const codigo = await abrirScanner();
-      if (codigo) document.getElementById('barcode').value = codigo.trim();
-    } catch (e) {
-      console.error('scanner', e);
-    }
-  });
-}
 
 
 // 🔧 Preencher data de entrada com a data atual ao carregar a página

--- a/js/scanner.js
+++ b/js/scanner.js
@@ -1,13 +1,15 @@
 /**
- * scanner.js - Utilitário simples para leitura de códigos de barras e QR codes.
+ * scanner.js - Utilitário para leitura de códigos de barras e QR Codes.
  *
- * Usa a API BarcodeDetector quando disponível e faz fallback para ZXing
- * carregado via CDN. Retorna uma Promise que resolve com o valor lido
- * ou rejeita em caso de erro/fechamento.
+ * Abre a câmera do dispositivo usando a API BarcodeDetector quando
+ * disponível, fazendo fallback para a biblioteca ZXing. O resultado lido
+ * é retornado em uma Promise e pode opcionalmente preencher um campo
+ * informado por id.
  */
 
-export async function abrirScanner () {
+export async function abrirScanner (idCampoDestino) {
   return new Promise(async (resolve, reject) => {
+    // ---------- Overlay ----------
     const overlay = document.createElement('div');
     overlay.style.position = 'fixed';
     overlay.style.top = '0';
@@ -20,13 +22,27 @@ export async function abrirScanner () {
     overlay.style.justifyContent = 'center';
     overlay.style.zIndex = '9999';
 
+    const container = document.createElement('div');
+    container.style.position = 'relative';
+
     const video = document.createElement('video');
-    video.style.maxWidth = '90%';
-    video.style.maxHeight = '90%';
+    video.style.maxWidth = '90vw';
+    video.style.maxHeight = '90vh';
     video.setAttribute('playsinline', true);
-    overlay.appendChild(video);
+    video.addEventListener('click', e => e.stopPropagation());
+    container.appendChild(video);
+
+    const btnCancel = document.createElement('button');
+    btnCancel.textContent = 'Cancelar';
+    btnCancel.style.position = 'absolute';
+    btnCancel.style.top = '10px';
+    btnCancel.style.right = '10px';
+    container.appendChild(btnCancel);
+
+    overlay.appendChild(container);
     document.body.appendChild(overlay);
 
+    // ---------- Acesso à câmera ----------
     let stream;
     try {
       stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
@@ -45,12 +61,19 @@ export async function abrirScanner () {
     }
 
     const handleResult = code => {
+      if (idCampoDestino) {
+        const input = document.getElementById(idCampoDestino);
+        if (input) input.value = code;
+      }
       cleanup();
       resolve(code);
     };
 
+    const supportedFormats = ['ean_13', 'code_128', 'qr_code'];
+
+    // ---------- Detecção ----------
     if ('BarcodeDetector' in window) {
-      const detector = new BarcodeDetector({ formats: ['qr_code', 'ean_13', 'ean_8', 'code_128', 'code_39', 'code_93', 'upc_a', 'upc_e', 'itf', 'codabar', 'data_matrix'] });
+      const detector = new BarcodeDetector({ formats: supportedFormats });
       const scan = async () => {
         try {
           const results = await detector.detect(video);
@@ -74,9 +97,21 @@ export async function abrirScanner () {
       });
     }
 
-    overlay.addEventListener('click', () => {
+    // ---------- Fechamento ----------
+    overlay.addEventListener('click', e => {
+      if (e.target === overlay) {
+        cleanup();
+        reject(new Error('cancelled'));
+      }
+    });
+    btnCancel.addEventListener('click', e => {
+      e.stopPropagation();
       cleanup();
       reject(new Error('cancelled'));
     });
   });
 }
+
+// Torna a função acessível globalmente para chamadas inline
+window.abrirScanner = abrirScanner;
+

--- a/produtos.html
+++ b/produtos.html
@@ -102,7 +102,7 @@
             <label>Código (QR ou de barras):</label>
             <div style="display:flex;gap:5px;">
               <input type="text" id="barcode" />
-              <button type="button" id="btn-ler-barcode">Ler código</button>
+              <button type="button" id="btn-ler-barcode" onclick="abrirScanner('barcode')">Ler código</button>
             </div>
           </div>
 
@@ -157,6 +157,7 @@
   <script type="module" src="js/utils.js"></script>
   <script type="module" src="js/modalEntrada.js"></script>
   <script type="module" src="js/modais.js"></script>
+  <script type="module" src="js/scanner.js"></script>
   <script type="module" src="js/produtos.js"></script>
 
   <!-- ✅ Modal: Produto Já Existe -->


### PR DESCRIPTION
## Summary
- add flexible scanner utility with BarcodeDetector and ZXing fallback
- wire product code field to scanner and expose function globally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689635c21928832b8b82b064e46a24f6