### PR TITLE
Corrige sobreposição do modal de confirmação no cadastro de produtos

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -358,7 +358,6 @@ table tbody tr:hover {
 
 /* Modal */
 #modal-entrada,
-#modal-confirmacao,
 #modal-produto-existe {
   background: white;
   padding: 20px;
@@ -366,6 +365,15 @@ table tbody tr:hover {
   border: 1px solid #ddd;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   z-index: 1000;
+}
+
+#modal-confirmacao {
+  background: white;
+  padding: 20px;
+  border-radius: 10px;
+  border: 1px solid #ddd;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  z-index: 1600;
 }
 
 .modal {
@@ -393,6 +401,10 @@ table tbody tr:hover {
   top: 0; left: 0; right: 0; bottom: 0;
   background: rgba(0, 0, 0, 0.4);
   z-index: 500;
+}
+
+#fundo-modal-confirmacao {
+  z-index: 1500;
 }
 .modal-lateral {
   display: none;


### PR DESCRIPTION
## Summary
- Ajusta o z-index do modal de confirmação e do fundo para aparecerem sobre o modal financeiro

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a367584560832ba7e615e39571d70f