### PR TITLE
Prefill financial modal with existing purchase data

### DIFF
--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -109,21 +109,43 @@ export async function abrirModalEntrada(produto) {
     const forn = produto.fornecedor ? ` — Fornecedor: ${produto.fornecedor}` : "";
     nomeModal.textContent = `Produto: ${produto.nome}${forn}`;
   }
-  document.getElementById("entrada-forma-pagamento").value = "pix";
-  document.getElementById("entrada-observacoes").value = "";
-  const dataEntrada = new Date(produtoCadastroAtual.dataEntrada);
-  dataEntrada.setMonth(dataEntrada.getMonth() + 1);
-  document.getElementById("entrada-primeiro-vencimento").value = dataEntrada
-    .toISOString()
-    .split("T")[0];
-  mostrarBadgeProgramacao(false);
+
+  // Preencher campos financeiros já cadastrados, se existirem
+  document.getElementById("entrada-forma-pagamento").value = produto.formaPagamento || "pix";
+  document.getElementById("entrada-identificador-pagamento").value = produto.identificadorPagamento || "";
+  document.getElementById("entrada-observacoes").value = produto.observacoes || "";
+
+  const numParcelasEl = document.getElementById("entrada-numero-parcelas");
+  const primeiroVencEl = document.getElementById("entrada-primeiro-vencimento");
+
+  if (produto.parcelas && produto.parcelas.length > 0) {
+    dadosFinanceiroAtual = {
+      formaPagamento: produto.formaPagamento || "pix",
+      identificadorPagamento: produto.identificadorPagamento || "",
+      observacoes: produto.observacoes || "",
+      parcelas: produto.parcelas
+    };
+    if (numParcelasEl) numParcelasEl.value = produto.parcelas.length;
+    if (primeiroVencEl) primeiroVencEl.value = produto.parcelas[0].vencimento;
+    exibirParcelas(produto.parcelas);
+    mostrarBadgeProgramacao(true);
+  } else {
+    dadosFinanceiroAtual = null;
+    const dataEntrada = new Date(produtoCadastroAtual.dataEntrada);
+    dataEntrada.setMonth(dataEntrada.getMonth() + 1);
+    if (primeiroVencEl) primeiroVencEl.value = dataEntrada.toISOString().split("T")[0];
+    if (numParcelasEl) numParcelasEl.value = 1;
+    atualizarParcelasPreview();
+    mostrarBadgeProgramacao(false);
+  }
 
   if (produto.compraId) {
     document.getElementById("entrada-compra-id").value = produto.compraId;
-    await preencherDadosFinanceiro(produto.compraId);
+    if (!produto.parcelas) {
+      await preencherDadosFinanceiro(produto.compraId);
+    }
     await atualizarTotalProvisorio(produto.compraId);
   } else {
-    atualizarParcelasPreview();
     await atualizarTotalProvisorio('');
   }
 

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -806,6 +806,12 @@ if (btnFinanceiro) {
 
     const mov = await obterUltimaMovimentacaoEntrada(editandoProdutoId);
 
+    // Buscar dados financeiros vinculados ao compraId, caso exista
+    let fin = null;
+    if (mov?.compraId) {
+      fin = await obterDadosFinanceiro(mov.compraId);
+    }
+
     const dados = {
       id: editandoProdutoId,
       nome,
@@ -818,7 +824,11 @@ if (btnFinanceiro) {
       validade: mov?.validade?.toDate ? mov.validade.toDate() : (mov?.validade || validadeForm),
       lote: mov?.lote || loteForm,
       compraId: mov?.compraId,
-      movimentacaoId: mov?.id
+      movimentacaoId: mov?.id,
+      formaPagamento: fin?.formaPagamento,
+      identificadorPagamento: fin?.identificadorPagamento,
+      observacoes: fin?.observacoes,
+      parcelas: Array.isArray(fin?.parcelas) ? fin.parcelas : undefined
     };
 
     abrirModalEntrada(dados);
@@ -1027,6 +1037,25 @@ async function obterUltimaMovimentacaoEntrada(produtoId) {
     }
   } catch (e) {
     console.error('Erro ao obter movimentação de entrada:', e);
+  }
+  return null;
+}
+
+// Buscar registro financeiro existente para um compraId
+async function obterDadosFinanceiro(compraId) {
+  if (!compraId) return null;
+  try {
+    const empresaId = await getEmpresaIdDoUsuario();
+    const q = query(
+      collection(db, 'empresas', empresaId, 'financeiro'),
+      where('compraId', '==', compraId)
+    );
+    const snap = await getDocs(q);
+    if (!snap.empty) {
+      return snap.docs[0].data();
+    }
+  } catch (e) {
+    console.error('Erro ao obter dados financeiros:', e);
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- prefill financial modal with all previously saved payment data
- reuse last financial record when editing products

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a375bdadb8832b9972cfd5dc2b52b7