### PR TITLE
feat: automatic purchase reconciliation

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -66,7 +66,6 @@
         <button id="botao-exportar-csv-fin" class="botao-acao" title="Exportar CSV">📄</button>
         <button id="botao-exportar-excel-fin" class="botao-acao" title="Exportar Excel">📊</button>
         <button id="botao-exportar-pdf-fin" class="botao-acao" title="Exportar PDF">🖨️</button>
-        <button id="btn-reconciliar-compra" class="botao-acao" title="Reconciliar compra">♻️</button>
       </div>
     </div>
     <p id="descricao-filtros-fin" class="descricao-filtros"></p>
@@ -148,20 +147,6 @@
     </div>
     <div id="fundo-modal-parcelas" class="fundo-modal" onclick="fecharModalParcelas()"></div>
 
-    <div id="modal-reconciliar" class="modal">
-      <div class="modal-content">
-        <h3>Reconciliar compra</h3>
-        <div class="form-group">
-          <label for="recon-compra-id">Compra ID</label>
-          <input type="text" id="recon-compra-id" />
-        </div>
-        <div style="text-align:right; margin-top:10px;">
-          <button onclick="fecharModal('modal-reconciliar')">Cancelar</button>
-          <button id="confirmar-reconciliar">Reconciliar</button>
-        </div>
-      </div>
-    </div>
-    <div id="fundo-modal-reconciliar" class="fundo-modal" onclick="fecharModal('modal-reconciliar')"></div>
   </main>
 </div>
 
@@ -175,26 +160,7 @@
 }
 </style>
 
-<script type="module">
-import { abrirModal, fecharModal } from './js/modais.js';
-import { reconciliarCompra, mostrarMensagem } from './js/utils.js';
 
-document.getElementById('btn-reconciliar-compra')?.addEventListener('click', () => {
-  const campo = document.getElementById('recon-compra-id');
-  const base = document.getElementById('fin-compra-id')?.value || '';
-  if (campo) campo.value = base;
-  abrirModal('modal-reconciliar');
-});
-
-document.getElementById('confirmar-reconciliar')?.addEventListener('click', async () => {
-  const compraId = document.getElementById('recon-compra-id').value.trim();
-  if (compraId) {
-    await reconciliarCompra(compraId);
-    mostrarMensagem('Compra reconciliada');
-  }
-  fecharModal('modal-reconciliar');
-});
-</script>
 
 <script type="module" src="js/firebaseConfig.js"></script>
 <script type="module" src="js/utils.js"></script>

--- a/js/modalEntrada.js
+++ b/js/modalEntrada.js
@@ -16,7 +16,7 @@ import {
   deleteField
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
-import { mostrarErro, normalizarTexto, parseDataLocal, formatarCompraIdBR, formatarPreco, formatarDataBrasileira } from './utils.js';
+import { mostrarErro, normalizarTexto, parseDataLocal, formatarCompraIdBR, formatarPreco, formatarDataBrasileira, reconciliarCompra } from './utils.js';
 import { registrarHistorico } from './historico.js';
 import { abrirModalConfirmacao } from './modais.js';
 
@@ -252,6 +252,9 @@ window.cancelarEntradaFinanceira = function () {
             novaQtd + (produtoCadastroAtual.quantidade || 0),
             novaQtd
           );
+          if (produtoCadastroAtual.compraId) {
+            await reconciliarCompra(produtoCadastroAtual.compraId);
+          }
           if (window.carregarMovimentacoes) window.carregarMovimentacoes();
           alert("Movimentação removida.");
         }
@@ -395,6 +398,7 @@ window.gerarNovoCompraId = async function () {
 
 window.confirmarEntradaEstoque = async function () {
   try {
+    const compraIdAntigo = produtoCadastroAtual.compraId;
     const formaPagamento = document.getElementById("entrada-forma-pagamento").value;
     const observacoes = document.getElementById("entrada-observacoes").value.trim() || "";
     const compraId = document.getElementById("entrada-compra-id")?.value?.trim() || "";
@@ -618,6 +622,11 @@ window.confirmarEntradaEstoque = async function () {
         "entrada-numero-parcelas": numParcelas,
         "entrada-primeiro-vencimento": parcelas[0]?.vencimento || null
       });
+    }
+
+    await reconciliarCompra(compraId);
+    if (compraIdAntigo && compraIdAntigo !== compraId) {
+      await reconciliarCompra(compraIdAntigo);
     }
 
     alert("✅ Entrada no estoque registrada e financeiro atualizado com sucesso!");

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -530,9 +530,9 @@ async function salvarAlteracoesProduto() {
     }
 
     if (quantidadeMudou || precoMudou) {
-      const compraId = await obterCompraIdAtual(editandoProdutoId);
-      if (compraId) {
-        await reconciliarCompra(compraId);
+      const compraIds = await obterCompraIdsDoProduto(editandoProdutoId);
+      for (const cid of compraIds) {
+        await reconciliarCompra(cid);
       }
     }
 
@@ -767,7 +767,6 @@ const form = document.getElementById("form-produto");
 const btn = document.querySelector("#form-produto button[type='submit']");
 const btnCancelar = document.getElementById('cancelar-edicao');
 const btnFinanceiro = document.getElementById('btn-adicionar-financeiro');
-const btnConciliar = document.getElementById('btn-conciliar-compra');
 let listenerPadrao = null;
 
 if (barcodeParam) {
@@ -834,19 +833,6 @@ if (btnFinanceiro) {
     abrirModalEntrada(dados);
   });
   }
-
-if (btnConciliar) {
-  btnConciliar.addEventListener('click', async () => {
-    if (!editandoProdutoId) return;
-    const compraId = await obterCompraIdAtual(editandoProdutoId);
-    if (!compraId) {
-      alert('Nenhuma compra encontrada para conciliar.');
-      return;
-    }
-    await reconciliarCompra(compraId);
-    mostrarMensagem('Compra conciliada com sucesso!');
-  });
-}
 
 // 🔧 Preencher data de entrada com a data atual ao carregar a página
 const campoDataEntrada = document.getElementById("dataEntrada");
@@ -1060,25 +1046,25 @@ async function obterDadosFinanceiro(compraId) {
   return null;
 }
 
-// Buscar compraId mais recente de um produto
-async function obterCompraIdAtual(produtoId) {
+// Buscar todos os compraId associados às entradas de um produto
+async function obterCompraIdsDoProduto(produtoId) {
+  const ids = new Set();
   try {
     const empresaId = await getEmpresaIdDoUsuario();
     const q = query(
       collection(db, 'empresas', empresaId, 'movimentacoes'),
       where('produtoId', '==', produtoId),
-      where('tipo', '==', 'entrada'),
-      orderBy('dataMovimentacao', 'desc'),
-      limit(1)
+      where('tipo', '==', 'entrada')
     );
     const snap = await getDocs(q);
-    if (!snap.empty) {
-      return snap.docs[0].data().compraId || null;
-    }
+    snap.forEach(docSnap => {
+      const cid = docSnap.data().compraId;
+      if (cid) ids.add(cid);
+    });
   } catch (e) {
-    console.error('Erro ao obter compraId da movimentação:', e);
+    console.error('Erro ao obter compraIds do produto:', e);
   }
-  return null;
+  return Array.from(ids);
 }
 
 // ==========================

--- a/js/utils.js
+++ b/js/utils.js
@@ -7,7 +7,10 @@ import {
   where,
   getDocs,
   doc,
-  updateDoc
+  updateDoc,
+  runTransaction,
+  addDoc,
+  Timestamp
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 
 // ==========================
@@ -228,44 +231,94 @@ export async function reconciliarCompra(compraId) {
   });
 
   // c) Documento financeiro
-  const finQuery = query(
-    collection(db, 'empresas', empresaId, 'financeiro'),
-    where('compraId', '==', compraId)
-  );
+  const finCol = collection(db, 'empresas', empresaId, 'financeiro');
+  const finQuery = query(finCol, where('compraId', '==', compraId));
   const finSnap = await getDocs(finQuery);
-  if (finSnap.empty) return { totalAtual, mensagem: 'Financeiro não encontrado' };
-  const finDoc = finSnap.docs[0];
-  const finData = finDoc.data();
 
-  // d) Recalcular parcelas
-  const parcelas = Array.isArray(finData.parcelas) ? finData.parcelas.map(p => ({ ...p })) : [];
-  const totalPago = parcelas
-    .filter(p => p.status === 'pago')
-    .reduce((s, p) => s + (Number(p.valor) || 0), 0);
-
-  let restante = Math.max(totalAtual - totalPago, 0);
-  const pendentes = parcelas.filter(p => p.status !== 'pago');
-
-  if (pendentes.length === 0 && restante > 0) {
-    console.warn('⚠️ total atual excede parcelas pagas');
-  } else if (pendentes.length > 0) {
-    const valorCada = restante / pendentes.length;
-    parcelas.forEach(p => {
-      if (p.status !== 'pago') p.valor = valorCada;
+  if (finSnap.empty) {
+    // Se não existir doc financeiro, cria um básico para registrar o valor
+    await addDoc(finCol, {
+      tipo: 'pagar',
+      compraId,
+      valorTotal: totalAtual,
+      parcelas: [
+        {
+          numero: 1,
+          valor: totalAtual,
+          vencimento: new Date().toISOString().split('T')[0],
+          status: 'pendente'
+        }
+      ],
+      dataLancamento: Timestamp.now(),
+      status: 'pendente'
     });
+    mostrarMensagem(`Compra ${compraId} conciliada automaticamente`);
+    console.log('🔄 Reconciliar compra', compraId, { totalAtual });
+    return { totalAtual };
   }
 
+  const finDoc = finSnap.docs[0];
   const finRef = doc(db, 'empresas', empresaId, 'financeiro', finDoc.id);
-  await updateDoc(finRef, { valorTotal: totalAtual, parcelas });
 
-  const resumo = {
-    totalAnterior: finData.valorTotal || 0,
-    totalAtual,
-    totalPago,
-    restante
-  };
-  console.log('🔄 Reconciliar compra', compraId, resumo);
-  return resumo;
+  let mensagem = null;
+  await runTransaction(db, async tx => {
+    const finTx = await tx.get(finRef);
+    if (!finTx.exists()) return;
+    const finData = finTx.data();
+    const parcelas = Array.isArray(finData.parcelas)
+      ? finData.parcelas.map(p => ({ ...p }))
+      : [];
+
+    const totalPago = parcelas
+      .filter(p => p.status === 'pago')
+      .reduce((s, p) => s + (Number(p.valor) || 0), 0);
+
+    let restante = Math.max(totalAtual - totalPago, 0);
+    const pendIdx = [];
+    parcelas.forEach((p, i) => {
+      if (p.status !== 'pago') pendIdx.push(i);
+    });
+
+    // Verifica se há algo a conciliar
+    const valorPendentesAtual = pendIdx.reduce((s, i) => s + (Number(parcelas[i].valor) || 0), 0);
+    const precisaConciliar =
+      Math.round((finData.valorTotal || 0) * 100) !== Math.round(totalAtual * 100) ||
+      Math.round(valorPendentesAtual * 100) !== Math.round(restante * 100);
+
+    if (!precisaConciliar) return;
+
+    if (totalAtual < totalPago) {
+      // Overpayment
+      pendIdx.forEach(i => (parcelas[i].valor = 0));
+      mensagem = `⚠️ Pagamentos excedem total da compra ${compraId}`;
+    } else if (pendIdx.length === 0) {
+      if (restante > 0) {
+        mensagem = `⚠️ Sem parcelas pendentes para alocar R$ ${restante.toFixed(2)}`;
+      }
+    } else {
+      // Distribuição igualitária com ajuste na última parcela
+      const base = Math.floor((restante * 100) / pendIdx.length);
+      const valores = new Array(pendIdx.length).fill(base);
+      let diff = Math.round(restante * 100) - base * pendIdx.length;
+      valores[valores.length - 1] += diff;
+      pendIdx.forEach((idx, i) => {
+        parcelas[idx].valor = parseFloat((valores[i] / 100).toFixed(2));
+      });
+      mensagem = `Compra ${compraId} conciliada automaticamente`;
+    }
+
+    tx.update(finRef, { valorTotal: totalAtual, parcelas });
+    console.log('🔄 Reconciliar compra', compraId, {
+      totalAtual,
+      totalPago,
+      restante
+    });
+  });
+
+  if (mensagem) {
+    mostrarMensagem(mensagem);
+  }
+  return { totalAtual };
 }
 
 // Disponibiliza globalmente para chamadas manuais em páginas sem módulo

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -144,7 +144,6 @@
 
         <div class="campo-filtro" style="display:flex;align-items:end; gap:5px;">
           <button type="button" id="botao-limpar-filtros">Limpar filtros</button>
-          <button type="button" id="btn-reconciliar-compra">Reconciliar</button>
         </div>
       </div>
       <p id="contador-movimentacoes"></p>
@@ -231,20 +230,6 @@
   </div>
   </div>
 
-  <div id="modal-reconciliar" class="modal">
-    <div class="modal-content">
-      <h3>Reconciliar compra</h3>
-      <div class="form-group">
-        <label for="recon-compra-id">Compra ID</label>
-        <input type="text" id="recon-compra-id" />
-      </div>
-      <div style="text-align:right; margin-top:10px;">
-        <button onclick="fecharModal('modal-reconciliar')">Cancelar</button>
-        <button id="confirmar-reconciliar">Reconciliar</button>
-      </div>
-    </div>
-  </div>
-  <div id="fundo-modal-reconciliar" class="fundo-modal" onclick="fecharModal('modal-reconciliar')"></div>
 
   <!-- 🔥 Scripts -->
   <script type="module" src="js/auth.js"></script>
@@ -253,26 +238,7 @@
   <script type="module" src="js/modais.js"></script>
   <script type="module" src="js/movimentacoes.js"></script>
 
-<script type="module">
-import { abrirModal, fecharModal } from './js/modais.js';
-import { reconciliarCompra, mostrarMensagem } from './js/utils.js';
 
-document.getElementById('btn-reconciliar-compra')?.addEventListener('click', () => {
-  const campo = document.getElementById('recon-compra-id');
-  const base = document.getElementById('filtro-compra-mov')?.value || '';
-  if (campo) campo.value = base;
-  abrirModal('modal-reconciliar');
-});
-
-document.getElementById('confirmar-reconciliar')?.addEventListener('click', async () => {
-  const compraId = document.getElementById('recon-compra-id').value.trim();
-  if (compraId) {
-    await reconciliarCompra(compraId);
-    mostrarMensagem('Compra reconciliada');
-  }
-  fecharModal('modal-reconciliar');
-});
-</script>
 
 </body>
 </html>

--- a/produtos.html
+++ b/produtos.html
@@ -112,7 +112,6 @@
           </div>
           <div class="form-group full-width" id="financeiro-pendente-container" style="display:none; text-align:right;">
             <button type="button" id="btn-adicionar-financeiro">📄 Adicionar entrada financeira</button>
-            <button type="button" id="btn-conciliar-compra" style="margin-left:10px;">♻️ Conciliar compra</button>
           </div>
         </form>
       </section>


### PR DESCRIPTION
## Summary
- automate purchase reconciliation by recalculating totals and distributing pending installments
- trigger reconciliation on product edits and entry movement changes
- drop manual reconciliation buttons and modals from UI

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a385b70eb0832b861862a6f00f5999