### PR TITLE
refactor ParseResult interface

### DIFF
--- a/functions/src/nfe/parse.ts
+++ b/functions/src/nfe/parse.ts
@@ -1,11 +1,11 @@
 export interface ParseResult {
   chave: string;
-  resumo: { emit: any; dest: any; ide: any; total: any };
+  resumo: Record<string, unknown>;
   itens: any[];
 }
 
 export function parseNfe(xml: string): ParseResult {
   const match = xml.match(/<infNFe[^>]*Id="NFe(\d{44})"/);
   const chave = match ? match[1] : ''.padStart(44, '0');
-  return { chave, resumo: { emit: {}, dest: {}, ide: {}, total: {} }, itens: [] };
+  return { chave, resumo: {}, itens: [] };
 }


### PR DESCRIPTION
## Summary
- simplify ParseResult to use generic resumo record
- adjust parseNfe to return empty resumo

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: tsc: not found)
- `npm install` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a788acda28832b9949aaa0fe260c09